### PR TITLE
Rename classification_mappableConcept to classification in docs

### DIFF
--- a/docs/data-access/examples.md
+++ b/docs/data-access/examples.md
@@ -76,7 +76,7 @@ PG (practice guideline) and EP (reviewed by expert panel) submissions are aggreg
 
 | File | VCV | Submission Level | Description |
 | --- | --- | --- | --- |
-| [VCV-PG-example.jsonc](https://github.com/clingen-data-model/clinvar-gks/blob/main/examples/vcv/VCV-PG-example.jsonc) | VCV999999999 (hypothetical) | PG | Layer 1 base statement for a practice guideline submission. Uses standard `classification_mappableConcept` and `objectClassification` |
+| [VCV-PG-example.jsonc](https://github.com/clingen-data-model/clinvar-gks/blob/main/examples/vcv/VCV-PG-example.jsonc) | VCV999999999 (hypothetical) | PG | Layer 1 base statement for a practice guideline submission. Uses standard `classification` and `objectClassification` |
 | [VCV-EP-example.jsonc](https://github.com/clingen-data-model/clinvar-gks/blob/main/examples/vcv/VCV-EP-example.jsonc) | VCV999999999 (hypothetical) | EP | Layer 1 base statement for an expert panel submission. Same form as PG; only the submission level qualifier and review status differ |
 
 See [VCV Statements output reference](../output-reference/vcv-statements.md) for field documentation.

--- a/docs/output-reference/rcv-statements.md
+++ b/docs/output-reference/rcv-statements.md
@@ -25,20 +25,20 @@ Each record is a `Statement` with the following top-level fields:
 | `type` | string | Always `Statement` |
 | `direction` | string | Always `supports` |
 | `strength` | string | Always `definitive` |
-| `classification_mappableConcept` | object | Aggregate classification label as MappableConcept. See [Classification](#classification) |
+| `classification` | object | Aggregate classification label as MappableConcept. See [Classification](#classification) |
 | `proposition` | object | The aggregate proposition with variant, objectConditionClassification, and qualifiers. See [Proposition](#proposition) |
 | `extensions` | array | Aggregate metadata — `clinvarReviewStatus` |
 | `evidenceLines` | array | Contributing and non-contributing evidence from lower aggregation layers |
 
 </div>
 
-Like VCV, RCV statements use only `classification_mappableConcept` at every layer. PG and EP are independent submission levels.
+Like VCV, RCV statements use only `classification` at every layer. PG and EP are independent submission levels.
 
 ---
 
 ## Classification
 
-RCV statements always use a single `classification_mappableConcept` containing the aggregate classification label. The label format depends on the proposition type and submission level.
+RCV statements always use a single `classification` containing the aggregate classification label. The label format depends on the proposition type and submission level.
 
 ### Standard format
 
@@ -46,7 +46,7 @@ For most proposition types (pathogenicity, oncogenicity, association, etc.), the
 
 ```json
 {
-  "classification_mappableConcept": {
+  "classification": {
     "conceptType": "Classification",
     "name": "Pathogenic/Likely pathogenic",
     "extension": [
@@ -99,7 +99,7 @@ The `proposition` describes the condition-specific aggregate classification clai
     - A full `Condition` MappableConcept (id, name, conceptType, primaryCoding, mappings)
     - Or a full `ConditionSet` ConceptSet of conditions (id, conditions array, membershipOperator) — for SCVs with multiple conditions
    Extensions are excluded.
-2. **Classification** — the aggregate Classification (matching `classification_mappableConcept.name`).
+2. **Classification** — the aggregate Classification (matching `classification.name`).
 
 Single condition example:
 

--- a/docs/output-reference/vcv-statements.md
+++ b/docs/output-reference/vcv-statements.md
@@ -20,7 +20,7 @@ Each record is a `Statement` with the following top-level fields:
 | `type` | string | Always `Statement` |
 | `direction` | string | Always `supports` |
 | `strength` | string | Always `definitive` |
-| `classification_mappableConcept` | object | Aggregate classification label. See [Classification](#classification) |
+| `classification` | object | Aggregate classification label. See [Classification](#classification) |
 | `proposition` | object | The aggregate proposition with variant, objectClassification, and qualifiers. See [Proposition](#proposition) |
 | `extensions` | array | Aggregate metadata — `clinvarReviewStatus`. See [Extensions](#extensions) |
 | `evidenceLines` | array | Contributing and non-contributing evidence from lower aggregation layers. See [Evidence Lines](#evidence-lines) |
@@ -31,15 +31,15 @@ Each record is a `Statement` with the following top-level fields:
 
 ## Classification
 
-All VCV statements use a single `classification_mappableConcept` attribute for the aggregate classification.
+All VCV statements use a single `classification` attribute for the aggregate classification.
 
-### classification_mappableConcept
+### classification
 
 Used by all submission levels (PG, EP, CP, NOCP, NOCL, FLAG). Contains a single aggregate label with an optional `conflictingExplanation` extension when the classification is conflicting.
 
 ```json
 {
-  "classification_mappableConcept": {
+  "classification": {
     "conceptType": "Classification",
     "name": "Pathogenic/Likely pathogenic",
     "extension": [

--- a/docs/pipeline/rcv-statements/index.md
+++ b/docs/pipeline/rcv-statements/index.md
@@ -19,7 +19,7 @@ The pipeline is implemented across two stored procedures plus a JSON serializati
 - **Four-layer hierarchy** -- L1 (base) through L4 (group) progressively aggregate from individual SCVs to RCV-level summaries, following the same layer structure as VCV
 - **objectConditionClassification** -- RCV propositions use a single `objectConditionClassification` ConceptSet that always contains exactly **2 concepts**: the SCV's actual condition (or conditionSet) and the aggregate Classification. The same structure is used at every layer for every submission level
 - **Proposition type** -- `VariantAggregateConditionClassificationProposition` with predicate `hasAggregateConditionClassification`
-- **Single classification form** -- RCV uses only `classification_mappableConcept` at every layer, consistent with VCV
+- **Single classification form** -- RCV uses only `classification` at every layer, consistent with VCV
 
 ---
 

--- a/docs/pipeline/rcv-statements/rcv-extensions.md
+++ b/docs/pipeline/rcv-statements/rcv-extensions.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-RCV aggregate statement records contain `extensions` arrays at two structural levels -- on the top-level `Statement` and on the `classification_mappableConcept` object. Extensions carry aggregate review status information and classification context that are not part of the GA4GH VA-Spec statement model but are essential for interpreting the aggregation outcome.
+RCV aggregate statement records contain `extensions` arrays at two structural levels -- on the top-level `Statement` and on the `classification` object. Extensions carry aggregate review status information and classification context that are not part of the GA4GH VA-Spec statement model but are essential for interpreting the aggregation outcome.
 
 RCV statement extensions use `value` (not `value_string`) for extension values, following the convention for aggregate-level metadata.
 
@@ -48,9 +48,9 @@ Extensions on the top-level RCV `Statement` record, built in the [RCV Statement 
 
 ## Classification Extensions
 
-### classification_mappableConcept Extensions
+### classification Extensions
 
-Extensions on the `classification_mappableConcept` object. RCV uses `classification_mappableConcept` at every layer for every submission level.
+Extensions on the `classification` object. RCV uses `classification` at every layer for every submission level.
 
 <table>
   <thead>
@@ -61,7 +61,7 @@ Extensions on the `classification_mappableConcept` object. RCV uses `classificat
   </thead>
   <tbody>
     <tr>
-      <td><code>conflictingExplanation</code><br><em>classification_mappableConcept</em><br>string</td>
+      <td><code>conflictingExplanation</code><br><em>classification</em><br>string</td>
       <td>A formatted breakdown of the conflicting classification counts when multiple distinct significance values exist for a conflict-detectable proposition type. Format: <code>Pathogenic(3); Likely pathogenic(2)</code>. Present only when the classification is conflicting (i.e., when the classification name starts with "Conflicting classifications of").</td>
     </tr>
     <tr>

--- a/docs/pipeline/rcv-statements/rcv-proc.md
+++ b/docs/pipeline/rcv-statements/rcv-proc.md
@@ -139,7 +139,7 @@ Each BASE section reads from the corresponding aggregation table and produces a 
 
 | Field | Description |
 |---|---|
-| `classification_mappableConcept` | A Classification concept with `name` (the aggregate label) and optional `conflictingExplanation` extension. Used at every layer for every submission level |
+| `classification` | A Classification concept with `name` (the aggregate label) and optional `conflictingExplanation` extension. Used at every layer for every submission level |
 | `proposition` | Contains `objectConditionClassification` (a ConceptSet with exactly 2 concepts: the SCV's actual condition or conditionSet plus the aggregate Classification), `aggregateQualifiers`, `subjectVariant` reference, type `VariantAggregateConditionClassificationProposition`, and predicate `hasAggregateConditionClassification` |
 | `extensions` | Array with `clinvarReviewStatus` value |
 | `evidenceLines` | References to child layer IDs (SCV IDs for L1, contributing/non-contributing statement IDs for L2--L4) |
@@ -164,7 +164,7 @@ Layer-specific differences:
 
 ### Layer 1 PRE
 
-Inlines SCV evidence items from `gks_scv_statement_pre`. Evidence lines are rewritten to reference SCV IDs in `clinvar.submission:{scv_id}` format. The `classification_mappableConcept` and `proposition` fields are carried forward unchanged from the BASE.
+Inlines SCV evidence items from `gks_scv_statement_pre`. Evidence lines are rewritten to reference SCV IDs in `clinvar.submission:{scv_id}` format. The `classification` and `proposition` fields are carried forward unchanged from the BASE.
 
 **Output:** `temp_rcv_layer1_pre` <span class="role-badge badge-internal">Internal</span>
 
@@ -172,7 +172,7 @@ Inlines SCV evidence items from `gks_scv_statement_pre`. Evidence lines are rewr
 
 ### Layer 2 PRE
 
-Inlines Layer 1 PRE evidence items into Layer 2 statements (somatic only). The `classification_mappableConcept` and `proposition` fields are passed through unchanged. Contributing and non-contributing evidence lines are rebuilt with the full inlined Layer 1 PRE statement structures.
+Inlines Layer 1 PRE evidence items into Layer 2 statements (somatic only). The `classification` and `proposition` fields are passed through unchanged. Contributing and non-contributing evidence lines are rebuilt with the full inlined Layer 1 PRE statement structures.
 
 **Output:** `temp_rcv_layer2_pre` <span class="role-badge badge-internal">Internal</span>
 
@@ -180,7 +180,7 @@ Inlines Layer 1 PRE evidence items into Layer 2 statements (somatic only). The `
 
 ### Layer 3 PRE
 
-Inlines evidence items from either Layer 2 PRE or Layer 1 PRE (using COALESCE to check L2 first, then L1). The `classification_mappableConcept` and `proposition` fields are passed through unchanged from the BASE -- RCV uses a single ConceptSet form at every layer.
+Inlines evidence items from either Layer 2 PRE or Layer 1 PRE (using COALESCE to check L2 first, then L1). The `classification` and `proposition` fields are passed through unchanged from the BASE -- RCV uses a single ConceptSet form at every layer.
 
 **Output:** `temp_rcv_layer3_pre` <span class="role-badge badge-internal">Internal</span>
 
@@ -188,7 +188,7 @@ Inlines evidence items from either Layer 2 PRE or Layer 1 PRE (using COALESCE to
 
 ### Layer 4 PRE
 
-Inlines Layer 3 PRE evidence items into Layer 4 statements (germline only). The `classification_mappableConcept` and `proposition` fields are passed through unchanged. Contributing and non-contributing evidence lines are rebuilt with the full inlined Layer 3 PRE statement structures.
+Inlines Layer 3 PRE evidence items into Layer 4 statements (germline only). The `classification` and `proposition` fields are passed through unchanged. Contributing and non-contributing evidence lines are rebuilt with the full inlined Layer 3 PRE statement structures.
 
 **Output:** `temp_rcv_layer4_pre` <span class="role-badge badge-internal">Internal</span>
 

--- a/docs/pipeline/vcv-statements/index.md
+++ b/docs/pipeline/vcv-statements/index.md
@@ -16,7 +16,7 @@ The pipeline is implemented across two stored procedures plus a JSON serializati
 
 - **Submission levels** — PG, EP, CP, NOCP, NOCL, and FLAG — determine how classifications are combined and whether conflicts are detected. Each submission level aggregates independently; only matching levels can combine. Submission levels are ranked `PG > EP > CP > NOCP > NOCL > FLAG`, with PG always winning at the top
 - **Four-layer hierarchy** — L1 (base) through L4 (group) progressively aggregate from individual SCVs to variant-level summaries
-- **Single classification format** — all VCV statements use `classification_mappableConcept` as the aggregate classification attribute, with an optional `conflictingExplanation` extension when contributing SCVs disagree. The same single-attribute pattern applies to `objectClassification` within the proposition
+- **Single classification format** — all VCV statements use `classification` as the aggregate classification attribute, with an optional `conflictingExplanation` extension when contributing SCVs disagree. The same single-attribute pattern applies to `objectClassification` within the proposition
 
 ---
 

--- a/docs/pipeline/vcv-statements/vcv-aggregation-rules.md
+++ b/docs/pipeline/vcv-statements/vcv-aggregation-rules.md
@@ -52,21 +52,21 @@ This description is carried on the SCV classification and is not propagated onto
 
 Practice guideline submissions are aggregated independently. Like CP, concordance and conflict detection produce a single aggregate label.
 
-- **Output attribute:** `classification_mappableConcept`
+- **Output attribute:** `classification`
 - **Review status:** always `practice guideline`
 
 ### EP (Expert Panel)
 
 Expert panel submissions are aggregated independently. Like CP, concordance and conflict detection produce a single aggregate label.
 
-- **Output attribute:** `classification_mappableConcept`
+- **Output attribute:** `classification`
 - **Review status:** always `reviewed by expert panel`
 
 ### CP (Assertion Criteria Provided)
 
 Standard aggregation with concordance and conflict detection.
 
-- **Output attribute:** `classification_mappableConcept` — a single aggregate label
+- **Output attribute:** `classification` — a single aggregate label
 - **Concordant** — all contributing SCVs share the same classification: the label is the shared classification name
 - **Conflicting** — contributing SCVs have different classifications: the label becomes "Conflicting classifications of `<proposition_type>`" with a `conflictingExplanation` extension showing the breakdown (e.g., "Pathogenic(3); Likely pathogenic(2)")
 - **Review status upgrades:** CP submissions may receive upgraded review status based on submitter count and concordance (see [Aggregate Review Status](#aggregate-review-status))
@@ -75,14 +75,14 @@ Standard aggregation with concordance and conflict detection.
 
 Same aggregation logic as CP — concordance/conflict detection produces a single label.
 
-- **Output attribute:** `classification_mappableConcept`
+- **Output attribute:** `classification`
 - **No review status upgrade** — always "no assertion criteria provided" regardless of submitter count or concordance
 
 ### FLAG (Flagged Submissions)
 
 No aggregation logic. Flagged submissions always produce a fixed result.
 
-- **Output attribute:** `classification_mappableConcept`
+- **Output attribute:** `classification`
 - **Label:** always "no classifications from unflagged records"
 - **No conflict detection**
 
@@ -90,22 +90,22 @@ No aggregation logic. Flagged submissions always produce a fixed result.
 
 Passthrough with no aggregation logic.
 
-- **Output attribute:** `classification_mappableConcept`
+- **Output attribute:** `classification`
 - **Label:** always "not provided"
 
 ---
 
 ## Classification Output
 
-Every VCV statement uses a single `classification_mappableConcept` attribute to represent its aggregate classification. The proposition uses a matching single `objectClassification` field.
+Every VCV statement uses a single `classification` attribute to represent its aggregate classification. The proposition uses a matching single `objectClassification` field.
 
-### `classification_mappableConcept`
+### `classification`
 
 Used by all submission levels (PG, EP, CP, NOCP, NOCL, and FLAG). Contains a single aggregate label with an optional `conflictingExplanation` extension when contributing SCVs disagree.
 
 ```json
 {
-  "classification_mappableConcept": {
+  "classification": {
     "conceptType": "Classification",
     "name": "Pathogenic/Likely pathogenic",
     "extension": [
@@ -119,7 +119,7 @@ The `extension` array is only present when the classification is conflicting.
 
 ### Proposition `objectClassification`
 
-The proposition contains an `objectClassification` MappableConcept with the same name as the statement-level `classification_mappableConcept` but without the `conflictingExplanation` extension.
+The proposition contains an `objectClassification` MappableConcept with the same name as the statement-level `classification` but without the `conflictingExplanation` extension.
 
 ---
 

--- a/docs/pipeline/vcv-statements/vcv-extensions.md
+++ b/docs/pipeline/vcv-statements/vcv-extensions.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-VCV aggregate statement records contain `extensions` arrays at two structural levels — on the top-level `Statement` and on the `classification_mappableConcept`. Extensions carry aggregate review status information and classification context that are not part of the GA4GH VA-Spec statement model but are essential for interpreting the aggregation outcome.
+VCV aggregate statement records contain `extensions` arrays at two structural levels — on the top-level `Statement` and on the `classification`. Extensions carry aggregate review status information and classification context that are not part of the GA4GH VA-Spec statement model but are essential for interpreting the aggregation outcome.
 
 VCV statement extensions use `value` (not `value_string`) for extension values, following the convention for aggregate-level metadata.
 
@@ -46,9 +46,9 @@ Extensions on the top-level VCV `Statement` record, built in the [VCV Statement 
 
 ## Classification Extensions
 
-### classification_mappableConcept Extensions
+### classification Extensions
 
-Extensions on the `classification_mappableConcept` object. All VCV statements use this single classification attribute.
+Extensions on the `classification` object. All VCV statements use this single classification attribute.
 
 <table>
   <thead>
@@ -59,7 +59,7 @@ Extensions on the `classification_mappableConcept` object. All VCV statements us
   </thead>
   <tbody>
     <tr>
-      <td><code>conflictingExplanation</code><br><em>classification_mappableConcept</em><br>string</td>
+      <td><code>conflictingExplanation</code><br><em>classification</em><br>string</td>
       <td>A formatted breakdown of the conflicting classification counts when multiple distinct significance values exist for a conflict-detectable proposition type. Format: <code>Pathogenic(3); Likely pathogenic(2)</code>. Present only when the classification is conflicting (i.e., when the classification name starts with "Conflicting classifications of").</td>
     </tr>
     <tr>

--- a/docs/pipeline/vcv-statements/vcv-proc.md
+++ b/docs/pipeline/vcv-statements/vcv-proc.md
@@ -123,7 +123,7 @@ Each BASE section reads from the corresponding aggregation table and produces a 
 
 | Field | Description |
 |---|---|
-| `classification_mappableConcept` | A simple Classification concept with `name` and optional `conflictingExplanation` extension |
+| `classification` | A simple Classification concept with `name` and optional `conflictingExplanation` extension |
 | `proposition` | Contains `objectClassification` (a MappableConcept matching the statement classification), `aggregateQualifiers` (assertion group, proposition type, submission level, and optional tier), and `subjectVariant` reference |
 | `extensions` | Array with `clinvarReviewStatus` value |
 | `evidenceLines` | References to child layer IDs (SCV IDs for L1, contributing/non-contributing statement IDs for L2--L4) |
@@ -141,7 +141,7 @@ Layer-specific differences:
 
 ### Layer 1 PRE
 
-Inlines SCV evidence items into each Layer 1 BASE statement. Evidence lines are rewritten to reference SCV IDs in `clinvar.submission:{scv_id}` format. The `classification_mappableConcept` and `proposition` fields are carried forward from the BASE statement unchanged.
+Inlines SCV evidence items into each Layer 1 BASE statement. Evidence lines are rewritten to reference SCV IDs in `clinvar.submission:{scv_id}` format. The `classification` and `proposition` fields are carried forward from the BASE statement unchanged.
 
 **Output:** `temp_vcv_layer1_pre` <span class="role-badge badge-internal">Internal</span>
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -206,7 +206,7 @@ Key terms, acronyms, and concepts used throughout the ClinVar-GKS documentation.
 
 ## Classification Attributes (VCV)
 
-**classification_mappableConcept**
+**classification**
 :   VCV/RCV classification attribute. Contains a single aggregate label with optional `conflictingExplanation` extension.
 
 **objectClassification**


### PR DESCRIPTION
## Summary

Renames `classification_mappableConcept` to `classification` across all active documentation pages. The `normalizeAndKeyById` UDF strips the `_mappableConcept` suffix in the JSON output, so the consumer-facing field name is just `classification`.

11 files updated. Historical docs (`superpowers/plans/`, `drafts/`) left untouched.

## Test plan

- [ ] Verify `mkdocs build --strict` passes