### PR TITLE
Housekeeping: workflow fix, gitignore updates, CLAUDE.md rules

### DIFF
--- a/.github/workflows/update-gks-registry.yml
+++ b/.github/workflows/update-gks-registry.yml
@@ -6,7 +6,7 @@ on:
       full_refresh:
         description: 'Re-fetch all releases (not just new ones)'
         required: false
-        default: 'false'
+        default: false
         type: boolean
 
 jobs:

--- a/.gitignore
+++ b/.gitignore
@@ -14,9 +14,13 @@ __pycache__/
 # MkDocs build output
 site/
 
+# Schema build output
+schema/clinvar-gks/build/
+
 # IDE
 .vscode/
 .idea/
 .claude/settings.local.json
 .claude/Useful background for the documentation.md
 .claude/settings.json
+venv/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,6 +5,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## General Rules
 
 - Only modify files explicitly requested by the user. Do not proactively edit test files, SQL files, or other files beyond the scope of the current request without asking first.
+- Don't assume. Don't hide confusion. Surface tradeoffs.
+- Minimum code that solves the problem. Nothing speculative.
+- Touch only what you must. Clean up only your own mess.
+- Define success criteria. Loop until verified.
 
 ## Project Overview
 


### PR DESCRIPTION
## Summary

- **Workflow fix**: Change `full_refresh` default from `'false'` (string) to `false` (boolean) in `update-gks-registry.yml`
- **Gitignore updates**: Add `schema/clinvar-gks/build/` and `venv/` to `.gitignore`
- **CLAUDE.md rules**: Add general development rules (don't assume, minimum code, touch only what you must, define success criteria)