### PR TITLE
Refactor VCV/RCV/SCV procs for condition schema and upstream changes

### DIFF
--- a/src/procedures/gks-rcv-proc.sql
+++ b/src/procedures/gks-rcv-proc.sql
@@ -1,8 +1,8 @@
 CREATE OR REPLACE PROCEDURE `clinvar_ingest.gks_rcv_proc`(on_date DATE, debug BOOL)
 BEGIN
   DECLARE query_base STRING;
-  DECLARE query_grouping_base STRING;
-  DECLARE query_grouping_tier STRING;
+  DECLARE query_classification STRING;
+  DECLARE query_priority STRING;
   DECLARE query_agg_contribution STRING;
   DECLARE temp_create STRING;
 
@@ -42,7 +42,7 @@ BEGIN
 
           cct.label AS classif_label,
           cct.code as classif_type,
-          cct.original_description_order as classif_type_order,
+          cct.description_order as classif_type_order,
           cct.significance,
           cct.direction as scv_direction,
           cct.strength_label as scv_strength_name,
@@ -60,8 +60,10 @@ BEGIN
       JOIN `{S}.rcv_accession` AS ra ON rm.rcv_accession = ra.id
 
       JOIN `clinvar_ingest.clinvar_statement_types` AS cst ON cst.code = ss.statement_type
-      JOIN `clinvar_ingest.clinvar_clinsig_types` AS cct ON cct.code = ss.classif_type AND cct.statement_type = ss.statement_type
-      JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON cpt.code = ss.original_proposition_type
+      JOIN (
+        `clinvar_ingest.clinvar_clinsig_types` AS cct
+        JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON cpt.code = cct.proposition_type
+      ) ON cct.code = ss.classif_type AND cpt.statement_type_code = ss.statement_type
       LEFT JOIN `clinvar_ingest.submission_level` sl ON sl.rank = ss.rank
     """, '{S}', rec.schema_name);
     SET query_base = REPLACE(query_base, '{CT}', temp_create);
@@ -69,10 +71,10 @@ BEGIN
     EXECUTE IMMEDIATE query_base;
 
     -------------------------------------------------------------------------
-    -- GROUPING LAYER: BASE GROUPING
+    -- GROUPING LAYER: CLASSIFICATION GROUPING
     -------------------------------------------------------------------------
-    SET query_grouping_base = REPLACE("""
-      CREATE OR REPLACE TABLE `{S}.gks_rcv_grouping_base_agg` AS
+    SET query_classification = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_rcv_classification_agg` AS
       WITH
       core_agg AS (
           SELECT
@@ -181,14 +183,14 @@ BEGIN
         *
       FROM final_prep
     """, '{S}', rec.schema_name);
-    SET query_grouping_base = REPLACE(query_grouping_base, '{P}', IF(debug, rec.schema_name, '_SESSION'));
-    EXECUTE IMMEDIATE query_grouping_base;
+    SET query_classification = REPLACE(query_classification, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE query_classification;
 
     -------------------------------------------------------------------------
-    -- GROUPING LAYER: TIER GROUPING (Somatic only)
+    -- GROUPING LAYER: PRIORITY GROUPING (Somatic only)
     -------------------------------------------------------------------------
-    SET query_grouping_tier = REPLACE("""
-      CREATE OR REPLACE TABLE `{S}.gks_rcv_grouping_tier_agg` AS
+    SET query_priority = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_rcv_priority_agg` AS
       WITH statement_base AS (
           SELECT
             variation_id, rcv_accession, full_rcv_id, trait_set_id, statement_group, prop_type, submission_level,
@@ -197,7 +199,7 @@ BEGIN
               tier_priority, prop_display_order, actual_agg_classif_label,
               agg_label_conflicting_explanation, unique_traits, full_scv_ids, id, tier_grouping
             ) ORDER BY tier_priority ASC, ARRAY_LENGTH(full_scv_ids) DESC) as findings
-          FROM `{S}.gks_rcv_grouping_base_agg`
+          FROM `{S}.gks_rcv_classification_agg`
           WHERE tier_grouping IS NOT NULL
           GROUP BY 1, 2, 3, 4, 5, 6, 7
       ),
@@ -232,7 +234,7 @@ BEGIN
         CAST(NULL AS STRING) AS aggregate_review_status
       FROM final_state_prep
     """, '{S}', rec.schema_name);
-    EXECUTE IMMEDIATE query_grouping_tier;
+    EXECUTE IMMEDIATE query_priority;
 
     -------------------------------------------------------------------------
     -- AGGREGATE CONTRIBUTION LAYER
@@ -245,15 +247,15 @@ BEGIN
             submission_level_label,
             agg_label, agg_label_conflicting_explanation, prop_display_order,
             aggregate_review_status
-          FROM `{S}.gks_rcv_grouping_tier_agg`
-          LEFT JOIN (SELECT DISTINCT prop_type as pt, MIN(prop_display_order) as prop_display_order FROM `{S}.gks_rcv_grouping_base_agg` GROUP BY 1) ON prop_type = pt
+          FROM `{S}.gks_rcv_priority_agg`
+          LEFT JOIN (SELECT DISTINCT prop_type as pt, MIN(prop_display_order) as prop_display_order FROM `{S}.gks_rcv_classification_agg` GROUP BY 1) ON prop_type = pt
           UNION ALL
           SELECT
             id as source_id, variation_id, rcv_accession, full_rcv_id, trait_set_id, statement_group, prop_type, submission_level,
             submission_level_label,
             actual_agg_classif_label as agg_label, agg_label_conflicting_explanation, prop_display_order,
             aggregate_review_status
-          FROM `{S}.gks_rcv_grouping_base_agg`
+          FROM `{S}.gks_rcv_classification_agg`
           WHERE tier_grouping IS NULL
       ),
       ranked_levels AS (

--- a/src/procedures/gks-rcv-statement-proc.sql
+++ b/src/procedures/gks-rcv-statement-proc.sql
@@ -1,11 +1,11 @@
 CREATE OR REPLACE PROCEDURE `clinvar_ingest.gks_rcv_statement_proc`(on_date DATE, debug BOOL)
 BEGIN
   DECLARE query_condition_data STRING;
-  DECLARE query_grouping_base STRING;
-  DECLARE query_grouping_tier STRING;
+  DECLARE query_classification STRING;
+  DECLARE query_priority STRING;
   DECLARE query_agg_contribution STRING;
-  DECLARE query_grouping_base_pre STRING;
-  DECLARE query_grouping_tier_pre STRING;
+  DECLARE query_classification_pre STRING;
+  DECLARE query_priority_pre STRING;
   DECLARE query_agg_contribution_pre STRING;
   DECLARE query_rcv_pre STRING;
   DECLARE temp_create STRING;
@@ -23,9 +23,9 @@ BEGIN
     IF NOT debug THEN
       CALL `clinvar_ingest.cleanup_temp_tables`(rec.schema_name, [
         'temp_rcv_condition_data',
-        'temp_rcv_grouping_base_statements', 'temp_rcv_grouping_tier_statements',
+        'temp_rcv_classification_statements', 'temp_rcv_priority_statements',
         'temp_rcv_agg_contribution_statements',
-        'temp_rcv_grouping_base_pre', 'temp_rcv_grouping_tier_pre',
+        'temp_rcv_classification_pre', 'temp_rcv_priority_pre',
         'temp_rcv_agg_contribution_pre'
       ]);
     END IF;
@@ -48,23 +48,11 @@ BEGIN
       )
       SELECT
         rsl.rcv_accession,
-        IF(scs.condition IS NOT NULL,
-          TO_JSON(STRUCT(
-            scs.condition.id,
-            scs.condition.name,
-            scs.condition.conceptType,
-            scs.condition.primaryCoding,
-            scs.condition.mappings
-          )),
-          TO_JSON(STRUCT(
-            'ConceptSet' AS type,
-            scs.conditionSet.id,
-            ARRAY(
-              SELECT AS STRUCT c.id, c.name, c.conceptType, c.primaryCoding, c.mappings
-              FROM UNNEST(scs.conditionSet.conditions) c
-            ) AS conditions,
-            scs.conditionSet.membershipOperator
-          ))
+        COALESCE(
+          scs.extensions.value_submitted_condition.condition,
+          scs.extensions.value_submitted_condition.conditionSet,
+          scs.extensions.value_submitted_condition_set.condition,
+          scs.extensions.value_submitted_condition_set.conditionSet
         ) AS condition_concept
       FROM rcv_scv_link rsl
       JOIN `{S}.gks_scv_condition_sets` scs ON scs.scv_id = rsl.scv_id
@@ -75,10 +63,10 @@ BEGIN
     EXECUTE IMMEDIATE query_condition_data;
 
     -------------------------------------------------------------------------
-    -- GROUPING LAYER: BASE GROUPING
+    -- GROUPING LAYER: CLASSIFICATION GROUPING
     -------------------------------------------------------------------------
-    SET query_grouping_base = REPLACE("""
-      {CT} `{P}.temp_rcv_grouping_base_statements` AS
+    SET query_classification = REPLACE("""
+      {CT} `{P}.temp_rcv_classification_statements` AS
       SELECT
         agg.id,
 
@@ -121,8 +109,22 @@ BEGIN
         STRUCT(
           cpt.gks_type AS type,
           agg.prop_id AS id,
-          FORMAT('clinvar:%s', agg.variation_id) AS subjectVariant,
-          cpt.gks_predicate AS predicate,
+          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
+          CASE cpt.gks_type
+            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
+            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
+            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
+            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
+            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
+            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
+            ELSE 'isClinvarUndefinedAssociationFor'
+          END AS predicate,
           rcd.condition_concept AS objectCondition
         ) AS proposition,
 
@@ -138,27 +140,27 @@ BEGIN
             'supports' AS directionOfEvidenceProvided,
             'contributing' AS strengthOfEvidenceProvided,
             ARRAY(
-              SELECT TO_JSON(STRUCT(scv_id AS id))
+              SELECT FORMAT('#/scv/clinvar.submission:%s', scv_id)
               FROM UNNEST(agg.full_scv_ids) AS scv_id
             ) AS evidenceItems
           )
         ] AS evidenceLines
 
-      FROM `{S}.gks_rcv_grouping_base_agg` agg
+      FROM `{S}.gks_rcv_classification_agg` agg
       LEFT JOIN `{P}.temp_rcv_condition_data` rcd ON rcd.rcv_accession = agg.rcv_accession
       LEFT JOIN `clinvar_ingest.submission_level` sl ON agg.submission_level = sl.code
       LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
     """, '{S}', rec.schema_name);
-    SET query_grouping_base = REPLACE(query_grouping_base, '{CT}', temp_create);
-    SET query_grouping_base = REPLACE(query_grouping_base, '{P}', IF(debug, rec.schema_name, '_SESSION'));
-    EXECUTE IMMEDIATE query_grouping_base;
+    SET query_classification = REPLACE(query_classification, '{CT}', temp_create);
+    SET query_classification = REPLACE(query_classification, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE query_classification;
 
 
     -------------------------------------------------------------------------
-    -- GROUPING LAYER: TIER GROUPING (Somatic only)
+    -- GROUPING LAYER: PRIORITY GROUPING (Somatic only)
     -------------------------------------------------------------------------
-    SET query_grouping_tier = REPLACE("""
-      {CT} `{P}.temp_rcv_grouping_tier_statements` AS
+    SET query_priority = REPLACE("""
+      {CT} `{P}.temp_rcv_priority_statements` AS
       SELECT
         agg.id,
 
@@ -193,8 +195,22 @@ BEGIN
         STRUCT(
           cpt.gks_type AS type,
           agg.prop_id AS id,
-          FORMAT('clinvar:%s', agg.variation_id) AS subjectVariant,
-          cpt.gks_predicate AS predicate,
+          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
+          CASE cpt.gks_type
+            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
+            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
+            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
+            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
+            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
+            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
+            ELSE 'isClinvarUndefinedAssociationFor'
+          END AS predicate,
           rcd.condition_concept AS objectCondition
         ) AS proposition,
 
@@ -211,7 +227,7 @@ BEGIN
               'supports' AS directionOfEvidenceProvided,
               'contributing' AS strengthOfEvidenceProvided,
               ARRAY(
-                SELECT TO_JSON(STRUCT(stmt_id AS id))
+                SELECT FORMAT('#/rcv/%s', stmt_id)
                 FROM UNNEST(agg.contributing_statement_ids) AS stmt_id
               ) AS evidenceItems
             ),
@@ -220,7 +236,7 @@ BEGIN
               'neutral' AS directionOfEvidenceProvided,
               'non-contributing' AS strengthOfEvidenceProvided,
               ARRAY(
-                SELECT TO_JSON(STRUCT(stmt_id AS id))
+                SELECT FORMAT('#/rcv/%s', stmt_id)
                 FROM UNNEST(agg.non_contributing_statement_ids) AS stmt_id
               ) AS evidenceItems
             )
@@ -229,14 +245,14 @@ BEGIN
              OR ARRAY_LENGTH(val.evidenceItems) > 0
         ) AS evidenceLines
 
-      FROM `{S}.gks_rcv_grouping_tier_agg` agg
+      FROM `{S}.gks_rcv_priority_agg` agg
       LEFT JOIN `{P}.temp_rcv_condition_data` rcd ON rcd.rcv_accession = agg.rcv_accession
       LEFT JOIN `clinvar_ingest.submission_level` sl ON agg.submission_level = sl.code
       LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
     """, '{S}', rec.schema_name);
-    SET query_grouping_tier = REPLACE(query_grouping_tier, '{CT}', temp_create);
-    SET query_grouping_tier = REPLACE(query_grouping_tier, '{P}', IF(debug, rec.schema_name, '_SESSION'));
-    EXECUTE IMMEDIATE query_grouping_tier;
+    SET query_priority = REPLACE(query_priority, '{CT}', temp_create);
+    SET query_priority = REPLACE(query_priority, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE query_priority;
 
     -------------------------------------------------------------------------
     -- AGGREGATE CONTRIBUTION LAYER
@@ -277,8 +293,22 @@ BEGIN
         STRUCT(
           cpt.gks_type AS type,
           agg.prop_id AS id,
-          FORMAT('clinvar:%s', agg.variation_id) AS subjectVariant,
-          cpt.gks_predicate AS predicate,
+          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
+          CASE cpt.gks_type
+            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
+            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
+            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
+            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
+            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
+            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
+            ELSE 'isClinvarUndefinedAssociationFor'
+          END AS predicate,
           rcd.condition_concept AS objectCondition
         ) AS proposition,
 
@@ -294,14 +324,14 @@ BEGIN
               'EvidenceLine' AS type,
               'supports' AS directionOfEvidenceProvided,
               'contributing' AS strengthOfEvidenceProvided,
-              [TO_JSON(STRUCT(agg.contributing_layer_id AS id))] AS evidenceItems
+              [FORMAT('#/rcv/%s', agg.contributing_layer_id)] AS evidenceItems
             ),
             STRUCT(
               'EvidenceLine' AS type,
               'neutral' AS directionOfEvidenceProvided,
               'non-contributing' AS strengthOfEvidenceProvided,
               ARRAY(
-                SELECT TO_JSON(STRUCT(nc.layer_id AS id))
+                SELECT FORMAT('#/rcv/%s', nc.layer_id)
                 FROM UNNEST(agg.non_contributing_details) AS nc
               ) AS evidenceItems
             )
@@ -322,8 +352,8 @@ BEGIN
     -- GROUPING BASE PRE: Base Grouping statements with inlined SCV evidence items
     -- All submission levels (PG, EP, CP, NOCP, NOCL, FLAG) use the same flow.
     -------------------------------------------------------------------------
-    SET query_grouping_base_pre = REPLACE("""
-      {CT} `{P}.temp_rcv_grouping_base_pre` AS
+    SET query_classification_pre = REPLACE("""
+      {CT} `{P}.temp_rcv_classification_pre` AS
       SELECT
         l1.id, l1.type, l1.direction, l1.strength, l1.confidence,
         l1.classification_mappableConcept,
@@ -335,23 +365,23 @@ BEGIN
             'supports' AS directionOfEvidenceProvided,
             'contributing' AS strengthOfEvidenceProvided,
             ARRAY(
-              SELECT TO_JSON(STRUCT(FORMAT('clinvar.submission:%s', scv_id) AS id))
+              SELECT FORMAT('#/scv/clinvar.submission:%s', scv_id)
               FROM UNNEST(agg.full_scv_ids) AS scv_id
             ) AS evidenceItems
           )
         ] AS evidenceLines
-      FROM `{P}.temp_rcv_grouping_base_statements` l1
-      JOIN `{S}.gks_rcv_grouping_base_agg` agg ON l1.id = agg.id
+      FROM `{P}.temp_rcv_classification_statements` l1
+      JOIN `{S}.gks_rcv_classification_agg` agg ON l1.id = agg.id
     """, '{S}', rec.schema_name);
-    SET query_grouping_base_pre = REPLACE(query_grouping_base_pre, '{CT}', temp_create);
-    SET query_grouping_base_pre = REPLACE(query_grouping_base_pre, '{P}', IF(debug, rec.schema_name, '_SESSION'));
-    EXECUTE IMMEDIATE query_grouping_base_pre;
+    SET query_classification_pre = REPLACE(query_classification_pre, '{CT}', temp_create);
+    SET query_classification_pre = REPLACE(query_classification_pre, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE query_classification_pre;
 
     -------------------------------------------------------------------------
     -- GROUPING TIER PRE: Tier Grouping statements with inlined Base Grouping evidence items
     -------------------------------------------------------------------------
-    SET query_grouping_tier_pre = REPLACE("""
-      {CT} `{P}.temp_rcv_grouping_tier_pre` AS
+    SET query_priority_pre = REPLACE("""
+      {CT} `{P}.temp_rcv_priority_pre` AS
       WITH
       l2_contributing AS (
         SELECT l2.id, ARRAY_AGG(TO_JSON(
@@ -359,10 +389,10 @@ BEGIN
             l1.classification_mappableConcept,
             l1.proposition, l1.extensions, l1.evidenceLines)
         )) AS evidenceItems
-        FROM `{P}.temp_rcv_grouping_tier_statements` l2
+        FROM `{P}.temp_rcv_priority_statements` l2
         CROSS JOIN UNNEST(l2.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
-        JOIN `{P}.temp_rcv_grouping_base_pre` l1 ON l1.id = JSON_VALUE(item, '$.id')
+        JOIN `{P}.temp_rcv_classification_pre` l1 ON l1.id = REGEXP_EXTRACT(item, r'#/rcv/(.+)')
         WHERE el.strengthOfEvidenceProvided = 'contributing'
         GROUP BY l2.id
       ),
@@ -372,10 +402,10 @@ BEGIN
             l1.classification_mappableConcept,
             l1.proposition, l1.extensions, l1.evidenceLines)
         )) AS evidenceItems
-        FROM `{P}.temp_rcv_grouping_tier_statements` l2
+        FROM `{P}.temp_rcv_priority_statements` l2
         CROSS JOIN UNNEST(l2.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
-        JOIN `{P}.temp_rcv_grouping_base_pre` l1 ON l1.id = JSON_VALUE(item, '$.id')
+        JOIN `{P}.temp_rcv_classification_pre` l1 ON l1.id = REGEXP_EXTRACT(item, r'#/rcv/(.+)')
         WHERE el.strengthOfEvidenceProvided = 'non-contributing'
         GROUP BY l2.id
       )
@@ -394,13 +424,13 @@ BEGIN
             CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRING, evidenceItems ARRAY<JSON>>>)
           )
         ) AS evidenceLines
-      FROM `{P}.temp_rcv_grouping_tier_statements` l2
+      FROM `{P}.temp_rcv_priority_statements` l2
       LEFT JOIN l2_contributing c ON l2.id = c.id
       LEFT JOIN l2_non_contributing nc ON l2.id = nc.id
     """, '{S}', rec.schema_name);
-    SET query_grouping_tier_pre = REPLACE(query_grouping_tier_pre, '{CT}', temp_create);
-    SET query_grouping_tier_pre = REPLACE(query_grouping_tier_pre, '{P}', IF(debug, rec.schema_name, '_SESSION'));
-    EXECUTE IMMEDIATE query_grouping_tier_pre;
+    SET query_priority_pre = REPLACE(query_priority_pre, '{CT}', temp_create);
+    SET query_priority_pre = REPLACE(query_priority_pre, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE query_priority_pre;
 
     -------------------------------------------------------------------------
     -- AGGREGATE CONTRIBUTION PRE: Aggregate Contribution statements with inlined Tier Grouping/Base Grouping evidence items
@@ -408,41 +438,38 @@ BEGIN
     SET query_agg_contribution_pre = REPLACE("""
       {CT} `{P}.temp_rcv_agg_contribution_pre` AS
       WITH
+      all_layer_statements AS (
+        SELECT id, type, direction, strength, confidence,
+          classification_mappableConcept, proposition, extensions, TO_JSON(evidenceLines) as evidenceLines
+        FROM `{P}.temp_rcv_priority_pre`
+        UNION ALL
+        SELECT id, type, direction, strength, confidence,
+          classification_mappableConcept, proposition, extensions, TO_JSON(evidenceLines) as evidenceLines
+        FROM `{P}.temp_rcv_classification_pre`
+      ),
       l3_contributing AS (
         SELECT l3.id, ARRAY_AGG(TO_JSON(
-          COALESCE(
-            (SELECT AS STRUCT l2p.type, l2p.id, l2p.direction, l2p.strength, l2p.confidence,
-              l2p.classification_mappableConcept,
-              l2p.proposition, l2p.extensions, l2p.evidenceLines
-             FROM `{P}.temp_rcv_grouping_tier_pre` l2p WHERE l2p.id = JSON_VALUE(item, '$.id')),
-            (SELECT AS STRUCT l1.type, l1.id, l1.direction, l1.strength, l1.confidence,
-              l1.classification_mappableConcept,
-              l1.proposition, l1.extensions, l1.evidenceLines
-             FROM `{P}.temp_rcv_grouping_base_pre` l1 WHERE l1.id = JSON_VALUE(item, '$.id'))
-          )
+          STRUCT(als.type, als.id, als.direction, als.strength, als.confidence,
+            als.classification_mappableConcept,
+            als.proposition, als.extensions, als.evidenceLines)
         )) AS evidenceItems
         FROM `{P}.temp_rcv_agg_contribution_statements` l3
         CROSS JOIN UNNEST(l3.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
+        JOIN all_layer_statements als ON als.id = REGEXP_EXTRACT(item, r'#/rcv/(.+)')
         WHERE el.strengthOfEvidenceProvided = 'contributing'
         GROUP BY l3.id
       ),
       l3_non_contributing AS (
         SELECT l3.id, ARRAY_AGG(TO_JSON(
-          COALESCE(
-            (SELECT AS STRUCT l2p.type, l2p.id, l2p.direction, l2p.strength, l2p.confidence,
-              l2p.classification_mappableConcept,
-              l2p.proposition, l2p.extensions, l2p.evidenceLines
-             FROM `{P}.temp_rcv_grouping_tier_pre` l2p WHERE l2p.id = JSON_VALUE(item, '$.id')),
-            (SELECT AS STRUCT l1.type, l1.id, l1.direction, l1.strength, l1.confidence,
-              l1.classification_mappableConcept,
-              l1.proposition, l1.extensions, l1.evidenceLines
-             FROM `{P}.temp_rcv_grouping_base_pre` l1 WHERE l1.id = JSON_VALUE(item, '$.id'))
-          )
+          STRUCT(als.type, als.id, als.direction, als.strength, als.confidence,
+            als.classification_mappableConcept,
+            als.proposition, als.extensions, als.evidenceLines)
         )) AS evidenceItems
         FROM `{P}.temp_rcv_agg_contribution_statements` l3
         CROSS JOIN UNNEST(l3.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
+        JOIN all_layer_statements als ON als.id = REGEXP_EXTRACT(item, r'#/rcv/(.+)')
         WHERE el.strengthOfEvidenceProvided = 'non-contributing'
         GROUP BY l3.id
       )
@@ -482,11 +509,11 @@ BEGIN
     -- Drop temp tables when not in debug mode
     IF NOT debug THEN
       DROP TABLE _SESSION.temp_rcv_condition_data;
-      DROP TABLE _SESSION.temp_rcv_grouping_base_statements;
-      DROP TABLE _SESSION.temp_rcv_grouping_tier_statements;
+      DROP TABLE _SESSION.temp_rcv_classification_statements;
+      DROP TABLE _SESSION.temp_rcv_priority_statements;
       DROP TABLE _SESSION.temp_rcv_agg_contribution_statements;
-      DROP TABLE _SESSION.temp_rcv_grouping_base_pre;
-      DROP TABLE _SESSION.temp_rcv_grouping_tier_pre;
+      DROP TABLE _SESSION.temp_rcv_classification_pre;
+      DROP TABLE _SESSION.temp_rcv_priority_pre;
       DROP TABLE _SESSION.temp_rcv_agg_contribution_pre;
     END IF;
 

--- a/src/procedures/gks-scv-statement-proc.sql
+++ b/src/procedures/gks-scv-statement-proc.sql
@@ -43,7 +43,7 @@ BEGIN
           scv.version,
           IF(
             cpt.gks_type IS NOT NULL,
-            STRUCT(cpt.gks_type as type, cpt.gks_predicate as pred),
+            STRUCT(cpt.gks_type as type, cct.final_predicate as pred),
             STRUCT('ClinvarUndefinedProposition' as type, 'isClinvarUndefinedAssociationFor' as pred)
           ) as proposition,
 
@@ -136,14 +136,14 @@ BEGIN
         JOIN `{S}.scv_summary` scv
         ON
           scv.id = ca.id
-        LEFT JOIN `clinvar_ingest.clinvar_clinsig_types` cct
-          ON
+        LEFT JOIN (
+          `clinvar_ingest.clinvar_clinsig_types` cct
+          JOIN `clinvar_ingest.clinvar_proposition_types` cpt
+            ON cpt.code = cct.proposition_type
+        ) ON
             cct.code = scv.classif_type
             AND
-            cct.statement_type = scv.statement_type
-        LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt
-          ON
-            cpt.code = scv.original_proposition_type
+            cpt.statement_type_code = scv.statement_type
         LEFT JOIN `clinvar_ingest.submission_level` sl
           ON
             sl.rank = scv.rank
@@ -335,8 +335,22 @@ BEGIN
       {CT} {P}.temp_gks_scv_proposition
       AS
         SELECT
-          scv.id as scv_id,          
-          FORMAT('clinvar.submission:%s', scv.id) as id,
+          scv.id as scv_id,
+          FORMAT('%s-%s', scv.id, CASE scv.proposition.type
+            WHEN 'VariantPathogenicityProposition' THEN 'PATH'
+            WHEN 'VariantOncogenicityProposition' THEN 'ONCO'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'CS'
+            WHEN 'ClinvarAffectsProposition' THEN 'AFF'
+            WHEN 'ClinvarAssociationProposition' THEN 'ASSOC'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'SENS'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'CONF'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'DR'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'NP'
+            WHEN 'ClinvarOtherProposition' THEN 'OTH'
+            WHEN 'ClinvarProtectiveProposition' THEN 'PROT'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'RF'
+            ELSE 'UNDEF'
+          END) as id,
           scv.proposition.type as type,
           FORMAT('#/variation/clinvar:%s', scv.variation_id) as subjectVariant,
           scv.proposition.pred as predicate,
@@ -404,7 +418,11 @@ BEGIN
         )
         SELECT
           scv.id as scv_id,
-          FORMAT('clinvar.submission:%s', scv.id) as id,
+          FORMAT('%s-%s', scv.id, CASE scv.clinical_impact_assertion_type
+            WHEN 'prognostic' THEN 'PROG'
+            WHEN 'diagnostic' THEN 'DIAG'
+            WHEN 'therapeutic' THEN 'TR'
+          END) as id,
           scv.evidence_line_target_proposition.type as type,
           FORMAT('#/variation/clinvar:%s', scv.variation_id) as subjectVariant,
           scv.evidence_line_target_proposition.pred as predicate,
@@ -627,7 +645,7 @@ BEGIN
       SELECT
         FORMAT('clinvar.submission:%s.%i', scv.id, scv.version) as id,
         'Statement' as type,
-        FORMAT('#/proposition/clinvar.submission:%s', scv.id) as proposition,
+        FORMAT('#/proposition/%s', sp.id) as proposition,
         STRUCT(
           scv.submitted_classification as name,
           IF(
@@ -713,7 +731,7 @@ BEGIN
             STRUCT(
               FORMAT('clinvar.submission:%s.%i', scv.id, scv.version) as id,
               'EvidenceLine' as type,
-              FORMAT('#/proposition/clinvar.submission:%s', scv.id) as proposition,
+              FORMAT('#/proposition/%s', stp.id) as proposition,
               'supports' as directionOfEvidenceProvided,
               CASE scv.classification_code
                 WHEN 'tier 1' THEN

--- a/src/procedures/gks-scv-statement-proc.sql
+++ b/src/procedures/gks-scv-statement-proc.sql
@@ -83,6 +83,7 @@ BEGIN
               END
           END as evidence_line_target_proposition,
 
+          cpt.code as proposition_type_code,
           scv.date_created,
           scv.date_last_updated,
           scv.local_key,
@@ -336,21 +337,7 @@ BEGIN
       AS
         SELECT
           scv.id as scv_id,
-          FORMAT('%s-%s', scv.id, CASE scv.proposition.type
-            WHEN 'VariantPathogenicityProposition' THEN 'PATH'
-            WHEN 'VariantOncogenicityProposition' THEN 'ONCO'
-            WHEN 'VariantClinicalSignificanceProposition' THEN 'CS'
-            WHEN 'ClinvarAffectsProposition' THEN 'AFF'
-            WHEN 'ClinvarAssociationProposition' THEN 'ASSOC'
-            WHEN 'ClinvarConfersSensitivityProposition' THEN 'SENS'
-            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'CONF'
-            WHEN 'ClinvarDrugResponseProposition' THEN 'DR'
-            WHEN 'ClinvarNotProvidedProposition' THEN 'NP'
-            WHEN 'ClinvarOtherProposition' THEN 'OTH'
-            WHEN 'ClinvarProtectiveProposition' THEN 'PROT'
-            WHEN 'ClinvarRiskFactorProposition' THEN 'RF'
-            ELSE 'UNDEF'
-          END) as id,
+          FORMAT('%s-%s', scv.id, UPPER(IFNULL(scv.proposition_type_code, 'UNDEF'))) as id,
           scv.proposition.type as type,
           FORMAT('#/variation/clinvar:%s', scv.variation_id) as subjectVariant,
           scv.proposition.pred as predicate,
@@ -418,11 +405,7 @@ BEGIN
         )
         SELECT
           scv.id as scv_id,
-          FORMAT('%s-%s', scv.id, CASE scv.clinical_impact_assertion_type
-            WHEN 'prognostic' THEN 'PROG'
-            WHEN 'diagnostic' THEN 'DIAG'
-            WHEN 'therapeutic' THEN 'TR'
-          END) as id,
+          FORMAT('%s-%s', scv.id, UPPER(tp.code)) as id,
           scv.evidence_line_target_proposition.type as type,
           FORMAT('#/variation/clinvar:%s', scv.variation_id) as subjectVariant,
           scv.evidence_line_target_proposition.pred as predicate,
@@ -471,6 +454,9 @@ BEGIN
         LEFT JOIN scv_drugs sd
         ON
           sd.scv_id = scv.id
+        LEFT JOIN `clinvar_ingest.clinvar_proposition_types` tp
+        ON
+          tp.gks_type = scv.evidence_line_target_proposition.type
         WHERE
           scv.evidence_line_target_proposition IS NOT NULL
     """, '{S}', rec.schema_name);

--- a/src/procedures/gks-vcv-proc.sql
+++ b/src/procedures/gks-vcv-proc.sql
@@ -1,8 +1,8 @@
 CREATE OR REPLACE PROCEDURE `clinvar_ingest.gks_vcv_proc`(on_date DATE, debug BOOL)
 BEGIN
   DECLARE query_base STRING;
-  DECLARE query_grouping_base STRING;
-  DECLARE query_grouping_tier STRING;
+  DECLARE query_classification STRING;
+  DECLARE query_priority STRING;
   DECLARE query_agg_contribution STRING;
   DECLARE temp_create STRING;
 
@@ -42,7 +42,7 @@ BEGIN
 
           cct.label AS classif_label,
           cct.code as classif_type,
-          cct.original_description_order as classif_type_order,
+          cct.description_order as classif_type_order,
           cct.significance,
           cct.direction as scv_direction,
           cct.strength_label as scv_strength_name,
@@ -56,8 +56,10 @@ BEGIN
       JOIN `{S}.variation_archive` AS va ON ss.variation_id = va.variation_id
 
       JOIN `clinvar_ingest.clinvar_statement_types` AS cst ON cst.code = ss.statement_type
-      JOIN `clinvar_ingest.clinvar_clinsig_types` AS cct ON cct.code = ss.classif_type AND cct.statement_type = ss.statement_type
-      JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON cpt.code = ss.original_proposition_type
+      JOIN (
+        `clinvar_ingest.clinvar_clinsig_types` AS cct
+        JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON cpt.code = cct.proposition_type
+      ) ON cct.code = ss.classif_type AND cpt.statement_type_code = ss.statement_type
       LEFT JOIN `clinvar_ingest.submission_level` sl ON sl.rank = ss.rank
     """, '{S}', rec.schema_name);
     SET query_base = REPLACE(query_base, '{CT}', temp_create);
@@ -65,12 +67,12 @@ BEGIN
     EXECUTE IMMEDIATE query_base;
 
     -------------------------------------------------------------------------
-    -- GROUPING LAYER: BASE GROUPING
+    -- GROUPING LAYER: CLASSIFICATION GROUPING
     -- Only matching submission_levels aggregate together (PG with PG,
     -- EP with EP, CP with CP, etc.). No PGEP grouping.
     -------------------------------------------------------------------------
-    SET query_grouping_base = REPLACE("""
-      CREATE OR REPLACE TABLE `{S}.gks_vcv_grouping_base_agg` AS
+    SET query_classification = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_vcv_classification_agg` AS
       WITH
       core_agg AS (
           SELECT
@@ -113,43 +115,25 @@ BEGIN
           WHERE b.prop_type = 'sci'
           GROUP BY 1, 2, 3, 4, 5
       ),
-      vcv_conditions_deduped AS (
-          -- Preserve top-level identity: single conditions keyed by trait_id,
-          -- conditionSets keyed by trait_set_id. Never flatten sets into traits.
-          SELECT variation_id, statement_group, prop_type, submission_level, tier_grouping,
-                 condition_ref, ANY_VALUE(condition_json) as condition_json
-          FROM (
-            -- Single conditions: reference by trait_id
-            SELECT b.variation_id, b.statement_group, b.prop_type, b.submission_level,
-                   IF(b.prop_type = 'sci', b.classif_type, CAST(NULL AS STRING)) as tier_grouping,
-                   scs.condition.id as condition_ref,
-                   TO_JSON(STRUCT(
-                     scs.condition.id as id,
-                     scs.condition.name, scs.condition.conceptType,
-                     scs.condition.primaryCoding, scs.condition.mappings
-                   )) as condition_json
-            FROM `{P}.temp_vcv_base_data` b
-            JOIN `{S}.gks_scv_condition_sets` scs ON b.scv_id = scs.scv_id
-            WHERE scs.condition IS NOT NULL
-            UNION ALL
-            -- ConditionSets: reference by trait_set_id (kept as atomic unit)
-            SELECT b.variation_id, b.statement_group, b.prop_type, b.submission_level,
-                   IF(b.prop_type = 'sci', b.classif_type, CAST(NULL AS STRING)) as tier_grouping,
-                   scs.conditionSet.id as condition_ref,
-                   TO_JSON(STRUCT(
-                     scs.conditionSet.id as id,
-                     scs.conditionSet.membershipOperator
-                   )) as condition_json
-            FROM `{P}.temp_vcv_base_data` b
-            JOIN `{S}.gks_scv_condition_sets` scs ON b.scv_id = scs.scv_id
-            WHERE scs.conditionSet IS NOT NULL
-          )
-          GROUP BY 1, 2, 3, 4, 5, 6
-      ),
       vcv_conditions AS (
-          SELECT variation_id, statement_group, prop_type, submission_level, tier_grouping,
-                 ARRAY_AGG(condition_json) as unique_conditions
-          FROM vcv_conditions_deduped
+          -- Collect unique condition/conditionSet IRI strings per grouping.
+          -- COALESCE across single/multi paths to handle SCV-RCV mismatches.
+          SELECT b.variation_id, b.statement_group, b.prop_type, b.submission_level,
+                 IF(b.prop_type = 'sci', b.classif_type, CAST(NULL AS STRING)) as tier_grouping,
+                 ARRAY_AGG(DISTINCT condition_ref IGNORE NULLS) as unique_conditions
+          FROM `{P}.temp_vcv_base_data` b
+          JOIN `{S}.gks_scv_condition_sets` scs ON b.scv_id = scs.scv_id
+          CROSS JOIN UNNEST([
+            COALESCE(
+              scs.extensions.value_submitted_condition.condition,
+              scs.extensions.value_submitted_condition_set.condition
+            ),
+            COALESCE(
+              scs.extensions.value_submitted_condition.conditionSet,
+              scs.extensions.value_submitted_condition_set.conditionSet
+            )
+          ]) AS condition_ref
+          WHERE condition_ref IS NOT NULL
           GROUP BY 1, 2, 3, 4, 5
       ),
       final_prep AS (
@@ -157,7 +141,7 @@ BEGIN
             c.variation_id, c.vcv_accession, c.full_vcv_id, c.statement_group, c.prop_type,
             c.submission_level, c.submission_level_label, c.tier_grouping, c.full_scv_ids,
             c.tier_priority, c.prop_display_order, COALESCE(sc.unique_traits, []) as unique_traits,
-            COALESCE(vc.unique_conditions, CAST([] AS ARRAY<JSON>)) as unique_conditions,
+            COALESCE(vc.unique_conditions, CAST([] AS ARRAY<STRING>)) as unique_conditions,
             c.scv_direction, c.scv_strength_name,
 
             -- Conflict explanation: suppressed for PG, EP, and FLAG (single-source levels)
@@ -216,14 +200,14 @@ BEGIN
         *
       FROM final_prep
     """, '{S}', rec.schema_name);
-    SET query_grouping_base = REPLACE(query_grouping_base, '{P}', IF(debug, rec.schema_name, '_SESSION'));
-    EXECUTE IMMEDIATE query_grouping_base;
+    SET query_classification = REPLACE(query_classification, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE query_classification;
 
     -------------------------------------------------------------------------
-    -- GROUPING LAYER: TIER GROUPING (Somatic only)
+    -- GROUPING LAYER: PRIORITY GROUPING (Somatic only)
     -------------------------------------------------------------------------
-    SET query_grouping_tier = REPLACE("""
-      CREATE OR REPLACE TABLE `{S}.gks_vcv_grouping_tier_agg` AS
+    SET query_priority = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_vcv_priority_agg` AS
       WITH statement_base AS (
           SELECT
             variation_id, vcv_accession, full_vcv_id, statement_group, prop_type, submission_level,
@@ -232,7 +216,7 @@ BEGIN
               tier_priority, prop_display_order, actual_agg_classif_label,
               agg_label_conflicting_explanation, unique_traits, unique_conditions, full_scv_ids, id, tier_grouping
             ) ORDER BY tier_priority ASC, ARRAY_LENGTH(full_scv_ids) DESC) as findings
-          FROM `{S}.gks_vcv_grouping_base_agg`
+          FROM `{S}.gks_vcv_classification_agg`
           WHERE tier_grouping IS NOT NULL
           GROUP BY 1, 2, 3, 4, 5, 6
       ),
@@ -269,7 +253,7 @@ BEGIN
         CAST(NULL AS STRING) AS aggregate_review_status
       FROM final_state_prep
     """, '{S}', rec.schema_name);
-    EXECUTE IMMEDIATE query_grouping_tier;
+    EXECUTE IMMEDIATE query_priority;
 
     -------------------------------------------------------------------------
     -- AGGREGATE CONTRIBUTION LAYER
@@ -283,15 +267,15 @@ BEGIN
             submission_level_label,
             agg_label, agg_label_conflicting_explanation, prop_display_order,
             aggregate_review_status, unique_conditions
-          FROM `{S}.gks_vcv_grouping_tier_agg`
-          LEFT JOIN (SELECT DISTINCT prop_type as pt, MIN(prop_display_order) as prop_display_order FROM `{S}.gks_vcv_grouping_base_agg` GROUP BY 1) ON prop_type = pt
+          FROM `{S}.gks_vcv_priority_agg`
+          LEFT JOIN (SELECT DISTINCT prop_type as pt, MIN(prop_display_order) as prop_display_order FROM `{S}.gks_vcv_classification_agg` GROUP BY 1) ON prop_type = pt
           UNION ALL
           SELECT
             id as source_id, variation_id, vcv_accession, full_vcv_id, statement_group, prop_type, submission_level,
             submission_level_label,
             actual_agg_classif_label as agg_label, agg_label_conflicting_explanation, prop_display_order,
             aggregate_review_status, unique_conditions
-          FROM `{S}.gks_vcv_grouping_base_agg`
+          FROM `{S}.gks_vcv_classification_agg`
           WHERE tier_grouping IS NULL
       ),
       ranked_levels AS (

--- a/src/procedures/gks-vcv-statement-proc.sql
+++ b/src/procedures/gks-vcv-statement-proc.sql
@@ -1,10 +1,10 @@
 CREATE OR REPLACE PROCEDURE `clinvar_ingest.gks_vcv_statement_proc`(on_date DATE, debug BOOL)
 BEGIN
-  DECLARE query_grouping_base STRING;
-  DECLARE query_grouping_tier STRING;
+  DECLARE query_classification STRING;
+  DECLARE query_priority STRING;
   DECLARE query_agg_contribution STRING;
-  DECLARE query_grouping_base_pre STRING;
-  DECLARE query_grouping_tier_pre STRING;
+  DECLARE query_classification_pre STRING;
+  DECLARE query_priority_pre STRING;
   DECLARE query_agg_contribution_pre STRING;
   DECLARE query_vcv_pre STRING;
   DECLARE temp_create STRING;
@@ -21,20 +21,20 @@ BEGIN
     -- Clean up any persistent temp tables from a prior debug run
     IF NOT debug THEN
       CALL `clinvar_ingest.cleanup_temp_tables`(rec.schema_name, [
-        'temp_vcv_grouping_base_statements', 'temp_vcv_grouping_tier_statements',
+        'temp_vcv_classification_statements', 'temp_vcv_priority_statements',
         'temp_vcv_agg_contribution_statements',
-        'temp_vcv_grouping_base_pre', 'temp_vcv_grouping_tier_pre',
+        'temp_vcv_classification_pre', 'temp_vcv_priority_pre',
         'temp_vcv_agg_contribution_pre'
       ]);
     END IF;
 
     -------------------------------------------------------------------------
-    -- GROUPING LAYER: BASE GROUPING
+    -- GROUPING LAYER: CLASSIFICATION GROUPING
     -- All submission levels use classification_mappableConcept (no PGEP
     -- per-SCV expansion).
     -------------------------------------------------------------------------
-    SET query_grouping_base = REPLACE("""
-      {CT} `{P}.temp_vcv_grouping_base_statements` AS
+    SET query_classification = REPLACE("""
+      {CT} `{P}.temp_vcv_classification_statements` AS
       SELECT
         agg.id,
 
@@ -75,19 +75,23 @@ BEGIN
         STRUCT(
           cpt.gks_type AS type,
           agg.prop_id AS id,
-          FORMAT('clinvar:%s', agg.variation_id) AS subjectVariant,
-          cpt.gks_predicate AS predicate,
-          IF(ARRAY_LENGTH(agg.unique_conditions) = 1,
-            agg.unique_conditions[OFFSET(0)],
-            IF(ARRAY_LENGTH(agg.unique_conditions) > 1,
-              TO_JSON(STRUCT(
-                'ConceptSet' AS type,
-                agg.unique_conditions AS concepts,
-                'OR' AS membershipOperator
-              )),
-              CAST(NULL AS JSON)
-            )
-          ) AS objectCondition
+          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
+          CASE cpt.gks_type
+            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
+            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
+            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
+            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
+            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
+            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
+            ELSE 'isClinvarUndefinedAssociationFor'
+          END AS predicate,
+          agg.unique_conditions AS objectCondition
         ) AS proposition,
 
         IF(
@@ -102,26 +106,26 @@ BEGIN
             'supports' AS directionOfEvidenceProvided,
             'contributing' AS strengthOfEvidenceProvided,
             ARRAY(
-              SELECT TO_JSON(STRUCT(scv_id AS id))
+              SELECT FORMAT('#/scv/clinvar.submission:%s', scv_id)
               FROM UNNEST(agg.full_scv_ids) AS scv_id
             ) AS evidenceItems
           )
         ] AS evidenceLines
 
-      FROM `{S}.gks_vcv_grouping_base_agg` agg
+      FROM `{S}.gks_vcv_classification_agg` agg
       LEFT JOIN `clinvar_ingest.submission_level` sl ON agg.submission_level = sl.code
       LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
     """, '{S}', rec.schema_name);
-    SET query_grouping_base = REPLACE(query_grouping_base, '{CT}', temp_create);
-    SET query_grouping_base = REPLACE(query_grouping_base, '{P}', IF(debug, rec.schema_name, '_SESSION'));
-    EXECUTE IMMEDIATE query_grouping_base;
+    SET query_classification = REPLACE(query_classification, '{CT}', temp_create);
+    SET query_classification = REPLACE(query_classification, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE query_classification;
 
 
     -------------------------------------------------------------------------
-    -- GROUPING LAYER: TIER GROUPING (Somatic only)
+    -- GROUPING LAYER: PRIORITY GROUPING (Somatic only)
     -------------------------------------------------------------------------
-    SET query_grouping_tier = REPLACE("""
-      {CT} `{P}.temp_vcv_grouping_tier_statements` AS
+    SET query_priority = REPLACE("""
+      {CT} `{P}.temp_vcv_priority_statements` AS
       SELECT
         agg.id,
 
@@ -156,19 +160,23 @@ BEGIN
         STRUCT(
           cpt.gks_type AS type,
           agg.prop_id AS id,
-          FORMAT('clinvar:%s', agg.variation_id) AS subjectVariant,
-          cpt.gks_predicate AS predicate,
-          IF(ARRAY_LENGTH(agg.unique_conditions) = 1,
-            agg.unique_conditions[OFFSET(0)],
-            IF(ARRAY_LENGTH(agg.unique_conditions) > 1,
-              TO_JSON(STRUCT(
-                'ConceptSet' AS type,
-                agg.unique_conditions AS concepts,
-                'OR' AS membershipOperator
-              )),
-              CAST(NULL AS JSON)
-            )
-          ) AS objectCondition
+          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
+          CASE cpt.gks_type
+            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
+            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
+            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
+            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
+            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
+            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
+            ELSE 'isClinvarUndefinedAssociationFor'
+          END AS predicate,
+          agg.unique_conditions AS objectCondition
         ) AS proposition,
 
         IF(
@@ -184,7 +192,7 @@ BEGIN
               'supports' AS directionOfEvidenceProvided,
               'contributing' AS strengthOfEvidenceProvided,
               ARRAY(
-                SELECT TO_JSON(STRUCT(stmt_id AS id))
+                SELECT FORMAT('#/vcv/%s', stmt_id)
                 FROM UNNEST(agg.contributing_statement_ids) AS stmt_id
               ) AS evidenceItems
             ),
@@ -193,7 +201,7 @@ BEGIN
               'neutral' AS directionOfEvidenceProvided,
               'non-contributing' AS strengthOfEvidenceProvided,
               ARRAY(
-                SELECT TO_JSON(STRUCT(stmt_id AS id))
+                SELECT FORMAT('#/vcv/%s', stmt_id)
                 FROM UNNEST(agg.non_contributing_statement_ids) AS stmt_id
               ) AS evidenceItems
             )
@@ -202,13 +210,13 @@ BEGIN
              OR ARRAY_LENGTH(val.evidenceItems) > 0
         ) AS evidenceLines
 
-      FROM `{S}.gks_vcv_grouping_tier_agg` agg
+      FROM `{S}.gks_vcv_priority_agg` agg
       LEFT JOIN `clinvar_ingest.submission_level` sl ON agg.submission_level = sl.code
       LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
     """, '{S}', rec.schema_name);
-    SET query_grouping_tier = REPLACE(query_grouping_tier, '{CT}', temp_create);
-    SET query_grouping_tier = REPLACE(query_grouping_tier, '{P}', IF(debug, rec.schema_name, '_SESSION'));
-    EXECUTE IMMEDIATE query_grouping_tier;
+    SET query_priority = REPLACE(query_priority, '{CT}', temp_create);
+    SET query_priority = REPLACE(query_priority, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE query_priority;
 
     -------------------------------------------------------------------------
     -- AGGREGATE CONTRIBUTION LAYER
@@ -249,19 +257,23 @@ BEGIN
         STRUCT(
           cpt.gks_type AS type,
           agg.prop_id AS id,
-          FORMAT('clinvar:%s', agg.variation_id) AS subjectVariant,
-          cpt.gks_predicate AS predicate,
-          IF(ARRAY_LENGTH(agg.unique_conditions) = 1,
-            agg.unique_conditions[OFFSET(0)],
-            IF(ARRAY_LENGTH(agg.unique_conditions) > 1,
-              TO_JSON(STRUCT(
-                'ConceptSet' AS type,
-                agg.unique_conditions AS concepts,
-                'OR' AS membershipOperator
-              )),
-              CAST(NULL AS JSON)
-            )
-          ) AS objectCondition
+          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
+          CASE cpt.gks_type
+            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
+            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
+            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
+            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
+            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
+            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
+            ELSE 'isClinvarUndefinedAssociationFor'
+          END AS predicate,
+          agg.unique_conditions AS objectCondition
         ) AS proposition,
 
         IF(
@@ -276,14 +288,14 @@ BEGIN
               'EvidenceLine' AS type,
               'supports' AS directionOfEvidenceProvided,
               'contributing' AS strengthOfEvidenceProvided,
-              [TO_JSON(STRUCT(agg.contributing_layer_id AS id))] AS evidenceItems
+              [FORMAT('#/vcv/%s', agg.contributing_layer_id)] AS evidenceItems
             ),
             STRUCT(
               'EvidenceLine' AS type,
               'neutral' AS directionOfEvidenceProvided,
               'non-contributing' AS strengthOfEvidenceProvided,
               ARRAY(
-                SELECT TO_JSON(STRUCT(nc.layer_id AS id))
+                SELECT FORMAT('#/vcv/%s', nc.layer_id)
                 FROM UNNEST(agg.non_contributing_details) AS nc
               ) AS evidenceItems
             )
@@ -300,11 +312,11 @@ BEGIN
     EXECUTE IMMEDIATE query_agg_contribution;
 
     -------------------------------------------------------------------------
-    -- GROUPING BASE PRE: Grouping Base statements with inlined SCV evidence references
+    -- GROUPING BASE PRE: Classification statements with inlined SCV evidence references
     -- No PGEP per-SCV expansion -- pass classification through unchanged.
     -------------------------------------------------------------------------
-    SET query_grouping_base_pre = REPLACE("""
-      {CT} `{P}.temp_vcv_grouping_base_pre` AS
+    SET query_classification_pre = REPLACE("""
+      {CT} `{P}.temp_vcv_classification_pre` AS
       SELECT
         l1.id, l1.type, l1.direction, l1.strength, l1.confidence,
         l1.classification_mappableConcept,
@@ -316,23 +328,23 @@ BEGIN
             'supports' AS directionOfEvidenceProvided,
             'contributing' AS strengthOfEvidenceProvided,
             ARRAY(
-              SELECT TO_JSON(STRUCT(FORMAT('clinvar.submission:%s', scv_id) AS id))
+              SELECT FORMAT('#/scv/clinvar.submission:%s', scv_id)
               FROM UNNEST(agg.full_scv_ids) AS scv_id
             ) AS evidenceItems
           )
         ] AS evidenceLines
-      FROM `{P}.temp_vcv_grouping_base_statements` l1
-      JOIN `{S}.gks_vcv_grouping_base_agg` agg ON l1.id = agg.id
+      FROM `{P}.temp_vcv_classification_statements` l1
+      JOIN `{S}.gks_vcv_classification_agg` agg ON l1.id = agg.id
     """, '{S}', rec.schema_name);
-    SET query_grouping_base_pre = REPLACE(query_grouping_base_pre, '{CT}', temp_create);
-    SET query_grouping_base_pre = REPLACE(query_grouping_base_pre, '{P}', IF(debug, rec.schema_name, '_SESSION'));
-    EXECUTE IMMEDIATE query_grouping_base_pre;
+    SET query_classification_pre = REPLACE(query_classification_pre, '{CT}', temp_create);
+    SET query_classification_pre = REPLACE(query_classification_pre, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE query_classification_pre;
 
     -------------------------------------------------------------------------
-    -- GROUPING TIER PRE: Grouping Tier statements with inlined Grouping Base evidence items
+    -- GROUPING TIER PRE: Priority statements with inlined Classification evidence items
     -------------------------------------------------------------------------
-    SET query_grouping_tier_pre = REPLACE("""
-      {CT} `{P}.temp_vcv_grouping_tier_pre` AS
+    SET query_priority_pre = REPLACE("""
+      {CT} `{P}.temp_vcv_priority_pre` AS
       WITH
       l2_contributing AS (
         SELECT l2.id, ARRAY_AGG(TO_JSON(
@@ -340,10 +352,10 @@ BEGIN
             l1.classification_mappableConcept,
             l1.proposition, l1.extensions, l1.evidenceLines)
         )) AS evidenceItems
-        FROM `{P}.temp_vcv_grouping_tier_statements` l2
+        FROM `{P}.temp_vcv_priority_statements` l2
         CROSS JOIN UNNEST(l2.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
-        JOIN `{P}.temp_vcv_grouping_base_pre` l1 ON l1.id = JSON_VALUE(item, '$.id')
+        JOIN `{P}.temp_vcv_classification_pre` l1 ON l1.id = REGEXP_EXTRACT(item, r'#/vcv/(.+)')
         WHERE el.strengthOfEvidenceProvided = 'contributing'
         GROUP BY l2.id
       ),
@@ -353,10 +365,10 @@ BEGIN
             l1.classification_mappableConcept,
             l1.proposition, l1.extensions, l1.evidenceLines)
         )) AS evidenceItems
-        FROM `{P}.temp_vcv_grouping_tier_statements` l2
+        FROM `{P}.temp_vcv_priority_statements` l2
         CROSS JOIN UNNEST(l2.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
-        JOIN `{P}.temp_vcv_grouping_base_pre` l1 ON l1.id = JSON_VALUE(item, '$.id')
+        JOIN `{P}.temp_vcv_classification_pre` l1 ON l1.id = REGEXP_EXTRACT(item, r'#/vcv/(.+)')
         WHERE el.strengthOfEvidenceProvided = 'non-contributing'
         GROUP BY l2.id
       )
@@ -375,55 +387,52 @@ BEGIN
             CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRING, evidenceItems ARRAY<JSON>>>)
           )
         ) AS evidenceLines
-      FROM `{P}.temp_vcv_grouping_tier_statements` l2
+      FROM `{P}.temp_vcv_priority_statements` l2
       LEFT JOIN l2_contributing c ON l2.id = c.id
       LEFT JOIN l2_non_contributing nc ON l2.id = nc.id
     """, '{S}', rec.schema_name);
-    SET query_grouping_tier_pre = REPLACE(query_grouping_tier_pre, '{CT}', temp_create);
-    SET query_grouping_tier_pre = REPLACE(query_grouping_tier_pre, '{P}', IF(debug, rec.schema_name, '_SESSION'));
-    EXECUTE IMMEDIATE query_grouping_tier_pre;
+    SET query_priority_pre = REPLACE(query_priority_pre, '{CT}', temp_create);
+    SET query_priority_pre = REPLACE(query_priority_pre, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE query_priority_pre;
 
     -------------------------------------------------------------------------
-    -- AGGREGATE CONTRIBUTION PRE: Agg Contribution statements with inlined Grouping Tier/Base evidence items
+    -- AGGREGATE CONTRIBUTION PRE: Agg Contribution statements with inlined Priority/Base evidence items
     -------------------------------------------------------------------------
     SET query_agg_contribution_pre = REPLACE("""
       {CT} `{P}.temp_vcv_agg_contribution_pre` AS
       WITH
+      all_layer_statements AS (
+        SELECT id, type, direction, strength, confidence,
+          classification_mappableConcept, proposition, extensions, TO_JSON(evidenceLines) as evidenceLines
+        FROM `{P}.temp_vcv_priority_pre`
+        UNION ALL
+        SELECT id, type, direction, strength, confidence,
+          classification_mappableConcept, proposition, extensions, TO_JSON(evidenceLines) as evidenceLines
+        FROM `{P}.temp_vcv_classification_pre`
+      ),
       l3_contributing AS (
         SELECT l3.id, ARRAY_AGG(TO_JSON(
-          COALESCE(
-            (SELECT AS STRUCT l2p.type, l2p.id, l2p.direction, l2p.strength, l2p.confidence,
-              l2p.classification_mappableConcept,
-              l2p.proposition, l2p.extensions, l2p.evidenceLines
-             FROM `{P}.temp_vcv_grouping_tier_pre` l2p WHERE l2p.id = JSON_VALUE(item, '$.id')),
-            (SELECT AS STRUCT l1.type, l1.id, l1.direction, l1.strength, l1.confidence,
-              l1.classification_mappableConcept,
-              l1.proposition, l1.extensions, l1.evidenceLines
-             FROM `{P}.temp_vcv_grouping_base_pre` l1 WHERE l1.id = JSON_VALUE(item, '$.id'))
-          )
+          STRUCT(als.type, als.id, als.direction, als.strength, als.confidence,
+            als.classification_mappableConcept,
+            als.proposition, als.extensions, als.evidenceLines)
         )) AS evidenceItems
         FROM `{P}.temp_vcv_agg_contribution_statements` l3
         CROSS JOIN UNNEST(l3.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
+        JOIN all_layer_statements als ON als.id = REGEXP_EXTRACT(item, r'#/vcv/(.+)')
         WHERE el.strengthOfEvidenceProvided = 'contributing'
         GROUP BY l3.id
       ),
       l3_non_contributing AS (
         SELECT l3.id, ARRAY_AGG(TO_JSON(
-          COALESCE(
-            (SELECT AS STRUCT l2p.type, l2p.id, l2p.direction, l2p.strength, l2p.confidence,
-              l2p.classification_mappableConcept,
-              l2p.proposition, l2p.extensions, l2p.evidenceLines
-             FROM `{P}.temp_vcv_grouping_tier_pre` l2p WHERE l2p.id = JSON_VALUE(item, '$.id')),
-            (SELECT AS STRUCT l1.type, l1.id, l1.direction, l1.strength, l1.confidence,
-              l1.classification_mappableConcept,
-              l1.proposition, l1.extensions, l1.evidenceLines
-             FROM `{P}.temp_vcv_grouping_base_pre` l1 WHERE l1.id = JSON_VALUE(item, '$.id'))
-          )
+          STRUCT(als.type, als.id, als.direction, als.strength, als.confidence,
+            als.classification_mappableConcept,
+            als.proposition, als.extensions, als.evidenceLines)
         )) AS evidenceItems
         FROM `{P}.temp_vcv_agg_contribution_statements` l3
         CROSS JOIN UNNEST(l3.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
+        JOIN all_layer_statements als ON als.id = REGEXP_EXTRACT(item, r'#/vcv/(.+)')
         WHERE el.strengthOfEvidenceProvided = 'non-contributing'
         GROUP BY l3.id
       )
@@ -462,11 +471,11 @@ BEGIN
 
     -- Drop temp tables when not in debug mode
     IF NOT debug THEN
-      DROP TABLE _SESSION.temp_vcv_grouping_base_statements;
-      DROP TABLE _SESSION.temp_vcv_grouping_tier_statements;
+      DROP TABLE _SESSION.temp_vcv_classification_statements;
+      DROP TABLE _SESSION.temp_vcv_priority_statements;
       DROP TABLE _SESSION.temp_vcv_agg_contribution_statements;
-      DROP TABLE _SESSION.temp_vcv_grouping_base_pre;
-      DROP TABLE _SESSION.temp_vcv_grouping_tier_pre;
+      DROP TABLE _SESSION.temp_vcv_classification_pre;
+      DROP TABLE _SESSION.temp_vcv_priority_pre;
       DROP TABLE _SESSION.temp_vcv_agg_contribution_pre;
     END IF;
 


### PR DESCRIPTION
## Summary
- Update all procs to use extensions-based condition IRI references (`#/condition/`, `#/conditionSet/`)
- Rename VCV/RCV grouping layers: `base` -> `classification`, `tier` -> `priority`
- Change evidenceItems from JSON objects to formatted string references (`#/scv/clinvar.submission:`, `#/vcv/`, `#/rcv/`)
- Add proposition ID acronyms (PATH, ONCO, PROG, DIAG, TR, etc.) to SCV proposition IDs
- Update subjectVariant to `#/variation/clinvar:{id}` format across all procs
- Adapt JOIN patterns for upstream `clinvar_proposition_types` refactor (depends on `clinvar-ingest-bq-tools` branch `refactor/normalize-proposition-types`)
- Replace `gks_predicate` with CASE-derived predicates in VCV/RCV statement procs
- Rename `original_description_order` to `description_order`

## Test plan
- [x] Deploy upstream `clinvar-ingest-bq-tools` branch `refactor/normalize-proposition-types` first
- [x] Deploy all 5 procs to BigQuery
- [x] Run SCV: `CALL clinvar_ingest.gks_scv_statement_proc(CURRENT_DATE(), TRUE)`
- [x] Run VCV: `CALL clinvar_ingest.gks_vcv_proc(CURRENT_DATE(), TRUE)` then `CALL clinvar_ingest.gks_vcv_statement_proc(CURRENT_DATE(), TRUE)`
- [x] Run RCV: `CALL clinvar_ingest.gks_rcv_proc(CURRENT_DATE(), TRUE)` then `CALL clinvar_ingest.gks_rcv_statement_proc(CURRENT_DATE(), TRUE)`
- [x] Verify proposition IDs have acronym suffixes (e.g., `SCV001234567-PATH`)
- [x] Verify evidenceItems are string references, not JSON objects
- [x] Verify objectCondition is an IRI string reference