### PR TITLE
Refactor JSON output: dictionary tables, MappableConcept patterns, export scripts

### DIFF
--- a/src/procedures/gks-catvar-proc.sql
+++ b/src/procedures/gks-catvar-proc.sql
@@ -841,7 +841,7 @@ BEGIN
         cv.type,
         cv.name,
         cvc.constraints,
-        [FORMAT('#/allele/%s', cv.vrs_allele_id)] as members,
+        IF(cv.vrs_allele_id IS NOT NULL, [FORMAT('#/allele/%s', cv.vrs_allele_id)], []) as members,
         cvext.extensions,
         vm.mappings
       FROM catvar cv

--- a/src/procedures/gks-catvar-proc.sql
+++ b/src/procedures/gks-catvar-proc.sql
@@ -155,45 +155,6 @@ BEGIN
     EXECUTE IMMEDIATE dict_location_query;
 
     -------------------------------------------------------------------------
-    -- Step 1e: Dictionary table - alleles (global, keyed by VRS allele id)
-    -------------------------------------------------------------------------
-    SET dict_allele_query = REPLACE("""
-      CREATE OR REPLACE TABLE `{S}.gks_dict_allele`
-      AS
-      WITH allele_expressions AS (
-        SELECT
-          vrs.out.id as allele_id,
-          ARRAY_AGG(STRUCT(
-            vrs.in.fmt as syntax,
-            vrs.in.source as value
-          )) as expressions
-        FROM `{S}.gks_vrs` vrs
-        WHERE vrs.out.id IS NOT NULL
-        GROUP BY vrs.out.id
-      )
-      SELECT
-        vrs.id as key,
-        JSON_STRIP_NULLS(TO_JSON(STRUCT(
-          vrs.id,
-          vrs.type,
-          vrs.digest,
-          ex.expressions[SAFE_OFFSET(0)].value as name,
-          vrs.state,
-          vrs.copies,
-          vrs.copyChange,
-          ex.expressions,
-          FORMAT('#/location/%s', vrs.location.id) as location
-        )), remove_empty => TRUE) as value
-      FROM (
-        SELECT DISTINCT out.*
-        FROM `{S}.gks_vrs`
-        WHERE out.id IS NOT NULL
-      ) vrs
-      LEFT JOIN allele_expressions ex ON ex.allele_id = vrs.id
-    """, '{S}', rec.schema_name);
-    EXECUTE IMMEDIATE dict_allele_query;
-
-    -------------------------------------------------------------------------
     -- Step 2: Contextual variant expressions with precedence-ranked naming
     -------------------------------------------------------------------------
     SET temp_ctxvar_expr_query = REPLACE("""
@@ -316,6 +277,42 @@ BEGIN
     SET temp_ctxvar_expr_query = REPLACE(temp_ctxvar_expr_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
 
     EXECUTE IMMEDIATE temp_ctxvar_expr_query;
+
+    -------------------------------------------------------------------------
+    -- Step 2b: Dictionary table - alleles (global, keyed by VRS allele id)
+    -- Uses temp_ctxvar_expression for full expression set (spdi + hgvs + gnomad)
+    -------------------------------------------------------------------------
+    SET dict_allele_query = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_allele`
+      AS
+      SELECT
+        vrs.id as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          vrs.id,
+          vrs.type,
+          vrs.digest,
+          exp.name,
+          vrs.state,
+          vrs.copies,
+          vrs.copyChange,
+          exp.expressions,
+          FORMAT('#/location/%s', vrs.location.id) as location
+        )), remove_empty => TRUE) as value
+      FROM (
+        SELECT DISTINCT out.*
+        FROM `{S}.gks_vrs`
+        WHERE out.id IS NOT NULL
+      ) vrs
+      LEFT JOIN {P}.temp_ctxvar_expression exp
+      ON
+        exp.variation_id = (
+          SELECT ANY_VALUE(v.in.variation_id)
+          FROM `{S}.gks_vrs` v
+          WHERE v.out.id = vrs.id
+        )
+    """, '{S}', rec.schema_name);
+    SET dict_allele_query = REPLACE(dict_allele_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE dict_allele_query;
 
     -------------------------------------------------------------------------
     -- Step 3: Contextual variants with VRS type mapping

--- a/src/procedures/gks-catvar-proc.sql
+++ b/src/procedures/gks-catvar-proc.sql
@@ -2,11 +2,15 @@ CREATE OR REPLACE PROCEDURE `clinvar_ingest.gks_catvar_proc`(on_date DATE, debug
 BEGIN
   DECLARE temp_seqref_query STRING;
   DECLARE temp_seqloc_query STRING;
+  DECLARE dict_seqref_query STRING;
+  DECLARE dict_location_query STRING;
+  DECLARE dict_allele_query STRING;
   DECLARE temp_ctxvar_expr_query STRING;
   DECLARE temp_ctxvar_query STRING;
   DECLARE temp_catvar_ext_query STRING;
+  DECLARE dict_gene_query STRING;
   DECLARE temp_catvar_map_query STRING;
-  DECLARE gks_catvar_pre_query STRING;
+  DECLARE dict_variation_query STRING;
 
   DECLARE temp_create STRING;
   DECLARE temp_prefix STRING;
@@ -105,6 +109,89 @@ BEGIN
     SET temp_seqloc_query = REPLACE(temp_seqloc_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
 
     EXECUTE IMMEDIATE temp_seqloc_query;
+
+    -------------------------------------------------------------------------
+    -- Step 1c: Dictionary table - sequence references (global, keyed by refgetAccession)
+    -------------------------------------------------------------------------
+    SET dict_seqref_query = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_sequence_reference`
+      AS
+      SELECT
+        sq.refgetAccession as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          'SequenceReference' as type,
+          sq.refgetAccession,
+          sq.name,
+          sq.moleculeType,
+          sq.residueAlphabet,
+          sq.extensions
+        )), remove_empty => TRUE) as value
+      FROM {P}.temp_seqref sq
+    """, '{S}', rec.schema_name);
+    SET dict_seqref_query = REPLACE(dict_seqref_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE dict_seqref_query;
+
+    -------------------------------------------------------------------------
+    -- Step 1d: Dictionary table - locations (global, keyed by location id)
+    -------------------------------------------------------------------------
+    SET dict_location_query = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_location`
+      AS
+      SELECT
+        sl.id as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          sl.id,
+          sl.type,
+          sl.digest,
+          sl.start,
+          sl.end,
+          sl.start_range,
+          sl.end_range,
+          FORMAT('#/sequenceReference/%s', sl.sequenceReference.refgetAccession) as sequenceReference
+        )), remove_empty => TRUE) as value
+      FROM {P}.temp_seqloc sl
+    """, '{S}', rec.schema_name);
+    SET dict_location_query = REPLACE(dict_location_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE dict_location_query;
+
+    -------------------------------------------------------------------------
+    -- Step 1e: Dictionary table - alleles (global, keyed by VRS allele id)
+    -------------------------------------------------------------------------
+    SET dict_allele_query = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_allele`
+      AS
+      WITH allele_expressions AS (
+        SELECT
+          vrs.out.id as allele_id,
+          ARRAY_AGG(STRUCT(
+            vrs.in.fmt as syntax,
+            vrs.in.source as value
+          )) as expressions
+        FROM `{S}.gks_vrs` vrs
+        WHERE vrs.out.id IS NOT NULL
+        GROUP BY vrs.out.id
+      )
+      SELECT
+        vrs.out.id as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          vrs.out.id as id,
+          vrs.out.type,
+          vrs.out.digest,
+          ex.expressions[SAFE_OFFSET(0)].value as name,
+          vrs.out.state,
+          vrs.out.copies,
+          vrs.out.copyChange,
+          ex.expressions,
+          FORMAT('#/location/%s', vrs.out.location.id) as location
+        )), remove_empty => TRUE) as value
+      FROM (
+        SELECT DISTINCT out.*
+        FROM `{S}.gks_vrs`
+        WHERE out.id IS NOT NULL
+      ) vrs
+      LEFT JOIN allele_expressions ex ON ex.allele_id = vrs.out.id
+    """, '{S}', rec.schema_name);
+    EXECUTE IMMEDIATE dict_allele_query;
 
     -------------------------------------------------------------------------
     -- Step 2: Contextual variant expressions with precedence-ranked naming
@@ -404,29 +491,12 @@ BEGIN
           ga.variation_id,
           ARRAY_AGG(
             STRUCT(
-              g.id as entrez_gene_id,
-              g.hgnc_id,
-              g.symbol,
+              FORMAT('#/gene/ncbigene:%s', ga.gene_id) as gene,
               ga.relationship_type,
-              ga.source,
-              IF(
-                g.hgnc_id is null,
-                [
-                  FORMAT('https://identifiers.org/ncbigene:%s',g.id),
-                  FORMAT('https://www.ncbi.nlm.nih.gov/gene/%s',g.id)
-                ],
-                [
-                  FORMAT('https://identifiers.org/%s',LOWER(g.hgnc_id)),
-                  FORMAT('https://identifiers.org/ncbigene:%s',g.id),
-                  FORMAT('https://www.ncbi.nlm.nih.gov/gene/%s',g.id)
-                ]
-              ) as iris
+              ga.source
             )
           ) as genes
         FROM `{S}.gene_association` ga
-        JOIN `{S}.gene` g
-        ON
-          g.id = ga.gene_id
         GROUP BY
           ga.variation_id
       ),
@@ -553,6 +623,36 @@ BEGIN
     EXECUTE IMMEDIATE temp_catvar_ext_query;
 
     -------------------------------------------------------------------------
+    -- Step 4b: Dictionary table - genes (global, keyed by ncbigene:{id})
+    -------------------------------------------------------------------------
+    SET dict_gene_query = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_gene`
+      AS
+      SELECT
+        FORMAT('ncbigene:%s', g.id) as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          g.id as entrez_gene_id,
+          g.hgnc_id,
+          g.symbol,
+          IF(
+            g.hgnc_id is null,
+            [
+              FORMAT('https://identifiers.org/ncbigene:%s', g.id),
+              FORMAT('https://www.ncbi.nlm.nih.gov/gene/%s', g.id)
+            ],
+            [
+              FORMAT('https://identifiers.org/%s', LOWER(g.hgnc_id)),
+              FORMAT('https://identifiers.org/ncbigene:%s', g.id),
+              FORMAT('https://www.ncbi.nlm.nih.gov/gene/%s', g.id)
+            ]
+          ) as iris
+        )), remove_empty => TRUE) as value
+      FROM `{S}.gene` g
+      WHERE g.id IN (SELECT DISTINCT gene_id FROM `{S}.gene_association`)
+    """, '{S}', rec.schema_name);
+    EXECUTE IMMEDIATE dict_gene_query;
+
+    -------------------------------------------------------------------------
     -- Step 5: Cross-reference mappings for categorical variants
     -------------------------------------------------------------------------
     SET temp_catvar_map_query = REPLACE("""
@@ -611,8 +711,8 @@ BEGIN
     -------------------------------------------------------------------------
     -- Step 6: Assemble preliminary categorical variant records with constraints
     -------------------------------------------------------------------------
-    SET gks_catvar_pre_query = REPLACE("""
-      CREATE OR REPLACE TABLE `{S}.gks_catvar_pre`
+    SET dict_variation_query = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_variation`
       AS
       WITH catvar AS (
         SELECT
@@ -621,17 +721,11 @@ BEGIN
           FORMAT('clinvar:%s', ctx.variation_id) as id,
           'CategoricalVariant' as type,
           ctx.catvar_name as name,
-          STRUCT(
-            ctx.name,
-            ctx.id,
-            ctx.digest,
-            ctx.type,
-            ctx.location,
-            ctx.state,
-            ctx.copies,
-            ctx.copyChange,
-            ctx.expressions
-          ) as member
+          -- Store allele/location refs for constraints
+          ctx.id as vrs_allele_id,
+          ctx.location.id as vrs_location_id,
+          ctx.copies,
+          ctx.copyChange
         FROM {P}.temp_ctxvar ctx
         -- safe guard for upstream vrs process that returns bad records
         WHERE ctx.variation_id is not null
@@ -641,7 +735,7 @@ BEGIN
         SELECT
           ctx.variation_id,
           'DefiningAlleleConstraint' as type,
-          '2/members/0/' as allele,
+          FORMAT('#/allele/%s', ctx.vrs_allele_id) as allele,
           null as location,
           null as matchCharacteristic,
           [ STRUCT(
@@ -670,7 +764,7 @@ BEGIN
           ctx.variation_id,
           'DefiningLocationConstraint' as type,
           null as allele,
-          '2/members/0/location/' as location,
+          FORMAT('#/location/%s', ctx.vrs_location_id) as location,
           STRUCT(
             STRUCT(
               'is_within' as code,
@@ -700,7 +794,7 @@ BEGIN
           null as location,
           null as matchCharacteristic,
           null as relations,
-          ctx.member.copies,
+          ctx.copies,
           null as copyChange
         FROM catvar ctx
         WHERE
@@ -715,7 +809,7 @@ BEGIN
           null as matchCharacteristic,
           null as relations,
           CAST(null as INTEGER) as copies,
-          ctx.member.copyChange
+          ctx.copyChange
         FROM catvar ctx
         WHERE
           ctx.catvar_type = 'CategoricalCnvChange'
@@ -747,7 +841,7 @@ BEGIN
         cv.type,
         cv.name,
         cvc.constraints,
-        [cv.member] as members,
+        [FORMAT('#/allele/%s', cv.vrs_allele_id)] as members,
         cvext.extensions,
         vm.mappings
       FROM catvar cv
@@ -761,9 +855,9 @@ BEGIN
       ON
         vm.variation_id = cv.variation_id
     """, '{S}', rec.schema_name);
-    SET gks_catvar_pre_query = REPLACE(gks_catvar_pre_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    SET dict_variation_query = REPLACE(dict_variation_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
 
-    EXECUTE IMMEDIATE gks_catvar_pre_query;
+    EXECUTE IMMEDIATE dict_variation_query;
 
     IF NOT debug THEN
       DROP TABLE _SESSION.temp_seqref;

--- a/src/procedures/gks-catvar-proc.sql
+++ b/src/procedures/gks-catvar-proc.sql
@@ -172,24 +172,24 @@ BEGIN
         GROUP BY vrs.out.id
       )
       SELECT
-        vrs.out.id as key,
+        vrs.id as key,
         JSON_STRIP_NULLS(TO_JSON(STRUCT(
-          vrs.out.id as id,
-          vrs.out.type,
-          vrs.out.digest,
+          vrs.id,
+          vrs.type,
+          vrs.digest,
           ex.expressions[SAFE_OFFSET(0)].value as name,
-          vrs.out.state,
-          vrs.out.copies,
-          vrs.out.copyChange,
+          vrs.state,
+          vrs.copies,
+          vrs.copyChange,
           ex.expressions,
-          FORMAT('#/location/%s', vrs.out.location.id) as location
+          FORMAT('#/location/%s', vrs.location.id) as location
         )), remove_empty => TRUE) as value
       FROM (
         SELECT DISTINCT out.*
         FROM `{S}.gks_vrs`
         WHERE out.id IS NOT NULL
       ) vrs
-      LEFT JOIN allele_expressions ex ON ex.allele_id = vrs.out.id
+      LEFT JOIN allele_expressions ex ON ex.allele_id = vrs.id
     """, '{S}', rec.schema_name);
     EXECUTE IMMEDIATE dict_allele_query;
 

--- a/src/procedures/gks-catvar-proc.sql
+++ b/src/procedures/gks-catvar-proc.sql
@@ -285,6 +285,13 @@ BEGIN
     SET dict_allele_query = REPLACE("""
       CREATE OR REPLACE TABLE `{S}.gks_dict_allele`
       AS
+      WITH allele_to_variation AS (
+        SELECT DISTINCT
+          vrs.out.id as allele_id,
+          vrs.in.variation_id
+        FROM `{S}.gks_vrs` vrs
+        WHERE vrs.out.id IS NOT NULL
+      )
       SELECT
         vrs.id as key,
         JSON_STRIP_NULLS(TO_JSON(STRUCT(
@@ -303,13 +310,8 @@ BEGIN
         FROM `{S}.gks_vrs`
         WHERE out.id IS NOT NULL
       ) vrs
-      LEFT JOIN {P}.temp_ctxvar_expression exp
-      ON
-        exp.variation_id = (
-          SELECT ANY_VALUE(v.in.variation_id)
-          FROM `{S}.gks_vrs` v
-          WHERE v.out.id = vrs.id
-        )
+      LEFT JOIN allele_to_variation atv ON atv.allele_id = vrs.id
+      LEFT JOIN {P}.temp_ctxvar_expression exp ON exp.variation_id = atv.variation_id
     """, '{S}', rec.schema_name);
     SET dict_allele_query = REPLACE(dict_allele_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
     EXECUTE IMMEDIATE dict_allele_query;

--- a/src/procedures/gks-json-proc.sql
+++ b/src/procedures/gks-json-proc.sql
@@ -2,6 +2,7 @@ CREATE OR REPLACE PROCEDURE `clinvar_ingest.gks_json_proc`(on_date DATE, output_
 BEGIN
 
   DECLARE gks_catvar_query STRING;
+  DECLARE query_statement_scv STRING;
   DECLARE query_statement_vcv STRING;
   DECLARE query_statement_rcv STRING;
 
@@ -35,6 +36,32 @@ BEGIN
         FROM x
       """, '{S}', rec.schema_name);
       EXECUTE IMMEDIATE gks_catvar_query;
+
+    END IF;
+
+    -------------------------------------------------------------------------
+    -- SCV statement JSON output
+    -------------------------------------------------------------------------
+    IF output_type IN ('scv', 'all') THEN
+
+      SET query_statement_scv = REPLACE("""
+        CREATE OR REPLACE TABLE `{S}.gks_scv_statement`
+        AS
+        WITH json_draft AS (
+          SELECT
+            tv.id,
+            JSON_STRIP_NULLS(
+              TO_JSON(tv),
+            remove_empty => TRUE
+            ) AS rec
+          FROM `{S}.gks_scv_statement_pre` AS tv
+        )
+        SELECT
+          json_draft.id,
+          `clinvar_ingest.normalizeAndKeyById`(json_draft.rec, true) as rec
+        FROM json_draft
+      """, '{S}', rec.schema_name);
+      EXECUTE IMMEDIATE query_statement_scv;
 
     END IF;
 

--- a/src/procedures/gks-json-proc.sql
+++ b/src/procedures/gks-json-proc.sql
@@ -15,35 +15,10 @@ BEGIN
     -------------------------------------------------------------------------
     IF output_type IN ('catvar', 'all') THEN
 
-      -- Dict: sequence references (keyed JSON object)
-      EXECUTE IMMEDIATE REPLACE("""
-        CREATE OR REPLACE TABLE `{S}.gks_catvar_dict_sequence_reference` AS
-        SELECT JSON_OBJECT(ARRAY_AGG(key), ARRAY_AGG(value)) as rec
-        FROM `{S}.gks_dict_sequence_reference`
-      """, '{S}', rec.schema_name);
-
-      -- Dict: locations (keyed JSON object)
-      EXECUTE IMMEDIATE REPLACE("""
-        CREATE OR REPLACE TABLE `{S}.gks_catvar_dict_location` AS
-        SELECT JSON_OBJECT(ARRAY_AGG(key), ARRAY_AGG(value)) as rec
-        FROM `{S}.gks_dict_location`
-      """, '{S}', rec.schema_name);
-
-      -- Dict: alleles (keyed JSON object)
-      EXECUTE IMMEDIATE REPLACE("""
-        CREATE OR REPLACE TABLE `{S}.gks_catvar_dict_allele` AS
-        SELECT JSON_OBJECT(ARRAY_AGG(key), ARRAY_AGG(value)) as rec
-        FROM `{S}.gks_dict_allele`
-      """, '{S}', rec.schema_name);
-
-      -- Dict: genes (keyed JSON object)
-      EXECUTE IMMEDIATE REPLACE("""
-        CREATE OR REPLACE TABLE `{S}.gks_catvar_dict_gene` AS
-        SELECT JSON_OBJECT(ARRAY_AGG(key), ARRAY_AGG(value)) as rec
-        FROM `{S}.gks_dict_gene`
-      """, '{S}', rec.schema_name);
-
-      -- Dict: variations (keyed JSON object, per-variation for NDJSON export)
+      -- Dict: variations (per-row NDJSON export)
+      -- The gks_dict_* tables (sequence_reference, location, allele, gene)
+      -- are already created by gks_catvar_proc as per-row key/value tables.
+      -- Assembly into keyed JSON dictionaries happens at export time.
       SET gks_catvar_query = REPLACE("""
         CREATE OR REPLACE TABLE `{S}.gks_catvar`
         AS

--- a/src/procedures/gks-json-proc.sql
+++ b/src/procedures/gks-json-proc.sql
@@ -15,6 +15,35 @@ BEGIN
     -------------------------------------------------------------------------
     IF output_type IN ('catvar', 'all') THEN
 
+      -- Dict: sequence references (keyed JSON object)
+      EXECUTE IMMEDIATE REPLACE("""
+        CREATE OR REPLACE TABLE `{S}.gks_catvar_dict_sequence_reference` AS
+        SELECT JSON_OBJECT(ARRAY_AGG(key), ARRAY_AGG(value)) as rec
+        FROM `{S}.gks_dict_sequence_reference`
+      """, '{S}', rec.schema_name);
+
+      -- Dict: locations (keyed JSON object)
+      EXECUTE IMMEDIATE REPLACE("""
+        CREATE OR REPLACE TABLE `{S}.gks_catvar_dict_location` AS
+        SELECT JSON_OBJECT(ARRAY_AGG(key), ARRAY_AGG(value)) as rec
+        FROM `{S}.gks_dict_location`
+      """, '{S}', rec.schema_name);
+
+      -- Dict: alleles (keyed JSON object)
+      EXECUTE IMMEDIATE REPLACE("""
+        CREATE OR REPLACE TABLE `{S}.gks_catvar_dict_allele` AS
+        SELECT JSON_OBJECT(ARRAY_AGG(key), ARRAY_AGG(value)) as rec
+        FROM `{S}.gks_dict_allele`
+      """, '{S}', rec.schema_name);
+
+      -- Dict: genes (keyed JSON object)
+      EXECUTE IMMEDIATE REPLACE("""
+        CREATE OR REPLACE TABLE `{S}.gks_catvar_dict_gene` AS
+        SELECT JSON_OBJECT(ARRAY_AGG(key), ARRAY_AGG(value)) as rec
+        FROM `{S}.gks_dict_gene`
+      """, '{S}', rec.schema_name);
+
+      -- Dict: variations (keyed JSON object, per-variation for NDJSON export)
       SET gks_catvar_query = REPLACE("""
         CREATE OR REPLACE TABLE `{S}.gks_catvar`
         AS

--- a/src/procedures/gks-json-proc.sql
+++ b/src/procedures/gks-json-proc.sql
@@ -25,7 +25,7 @@ BEGIN
               TO_JSON(cv),
               remove_empty => TRUE
             ) AS json_data
-          FROM `{S}.gks_catvar_pre` cv
+          FROM `{S}.gks_dict_variation` cv
         )
         SELECT
           x.id,
@@ -75,7 +75,7 @@ BEGIN
             scv.proposition.* EXCEPT (subjectVariant),
             var AS subjectVariant
           FROM `{S}.gks_scv_statement_pre` AS scv
-          JOIN `clingen-dev.{S}.gks_catvar_pre` AS var
+          JOIN `clingen-dev.{S}.gks_dict_variation` AS var
           ON
             scv.proposition.subjectVariant = var.id
         ),

--- a/src/procedures/gks-json-proc.sql
+++ b/src/procedures/gks-json-proc.sql
@@ -2,8 +2,6 @@ CREATE OR REPLACE PROCEDURE `clinvar_ingest.gks_json_proc`(on_date DATE, output_
 BEGIN
 
   DECLARE gks_catvar_query STRING;
-  DECLARE query_statement_scv_by_ref STRING;
-  DECLARE query_statement_scv_inline STRING;
   DECLARE query_statement_vcv STRING;
   DECLARE query_statement_rcv STRING;
 
@@ -37,76 +35,6 @@ BEGIN
         FROM x
       """, '{S}', rec.schema_name);
       EXECUTE IMMEDIATE gks_catvar_query;
-
-    END IF;
-
-    -------------------------------------------------------------------------
-    -- SCV statement by-ref JSON output
-    -------------------------------------------------------------------------
-    IF output_type IN ('scv_by_ref', 'all') THEN
-
-      SET query_statement_scv_by_ref = REPLACE("""
-        CREATE OR REPLACE TABLE `{S}.gks_scv_statement_by_ref`
-        AS
-        WITH json_draft AS (
-          SELECT
-            tv.id,
-            JSON_STRIP_NULLS(
-              TO_JSON(tv),
-            remove_empty => TRUE
-            ) AS rec
-          FROM `{S}.gks_scv_statement_pre` AS tv
-        )
-        select
-          json_draft.id,
-          `clinvar_ingest.normalizeAndKeyById`(json_draft.rec, true) as rec
-        from json_draft
-      """, '{S}', rec.schema_name);
-      EXECUTE IMMEDIATE query_statement_scv_by_ref;
-
-    END IF;
-
-    -------------------------------------------------------------------------
-    -- SCV statement inline JSON output
-    -------------------------------------------------------------------------
-    IF output_type IN ('scv_inline', 'all') THEN
-
-      SET query_statement_scv_inline = REPLACE("""
-        CREATE OR REPLACE TABLE `{S}.gks_scv_statement_inline`
-        AS
-        WITH inline_proposition AS (
-          SELECT
-            scv.proposition.* EXCEPT (subjectVariant),
-            var AS subjectVariant
-          FROM `{S}.gks_scv_statement_pre` AS scv
-          JOIN `clingen-dev.{S}.gks_dict_variation` AS var
-          ON
-            scv.proposition.subjectVariant = var.id
-        ),
-        inline_scv AS (
-          SELECT
-            scv.* EXCEPT (proposition),
-            inline_proposition AS proposition
-          FROM inline_proposition
-          JOIN `clingen-dev.{S}.gks_scv_statement_pre` AS scv
-          ON
-            scv.proposition.id = inline_proposition.id
-        ),
-        json_draft AS (
-          SELECT
-            tv.id,
-            JSON_STRIP_NULLS(
-              TO_JSON(tv),
-            remove_empty => TRUE
-            ) AS rec
-          FROM inline_scv tv
-        )
-        select
-          json_draft.id,
-          `clinvar_ingest.normalizeAndKeyById`(json_draft.rec, true) as rec
-        from json_draft
-      """, '{S}', rec.schema_name);
-      EXECUTE IMMEDIATE query_statement_scv_inline;
 
     END IF;
 

--- a/src/procedures/gks-rcv-statement-proc.sql
+++ b/src/procedures/gks-rcv-statement-proc.sql
@@ -7,6 +7,7 @@ BEGIN
   DECLARE query_classification_pre STRING;
   DECLARE query_priority_pre STRING;
   DECLARE query_agg_contribution_pre STRING;
+  DECLARE dict_rcv_proposition_query STRING;
   DECLARE query_rcv_pre STRING;
   DECLARE temp_create STRING;
 
@@ -106,27 +107,7 @@ BEGIN
           ) AS extension
         ) AS classification_mappableConcept,
 
-        STRUCT(
-          cpt.gks_type AS type,
-          agg.prop_id AS id,
-          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
-          CASE cpt.gks_type
-            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
-            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
-            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
-            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
-            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
-            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
-            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
-            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
-            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
-            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
-            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
-            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
-            ELSE 'isClinvarUndefinedAssociationFor'
-          END AS predicate,
-          rcd.condition_concept AS objectCondition
-        ) AS proposition,
+        FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
 
         IF(
           agg.aggregate_review_status IS NOT NULL,
@@ -147,9 +128,7 @@ BEGIN
         ] AS evidenceLines
 
       FROM `{S}.gks_rcv_classification_agg` agg
-      LEFT JOIN `{P}.temp_rcv_condition_data` rcd ON rcd.rcv_accession = agg.rcv_accession
       LEFT JOIN `clinvar_ingest.submission_level` sl ON agg.submission_level = sl.code
-      LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
     """, '{S}', rec.schema_name);
     SET query_classification = REPLACE(query_classification, '{CT}', temp_create);
     SET query_classification = REPLACE(query_classification, '{P}', IF(debug, rec.schema_name, '_SESSION'));
@@ -192,27 +171,7 @@ BEGIN
           ) AS extension
         ) AS classification_mappableConcept,
 
-        STRUCT(
-          cpt.gks_type AS type,
-          agg.prop_id AS id,
-          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
-          CASE cpt.gks_type
-            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
-            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
-            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
-            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
-            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
-            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
-            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
-            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
-            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
-            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
-            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
-            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
-            ELSE 'isClinvarUndefinedAssociationFor'
-          END AS predicate,
-          rcd.condition_concept AS objectCondition
-        ) AS proposition,
+        FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
 
         IF(
           agg.aggregate_review_status IS NOT NULL,
@@ -246,9 +205,7 @@ BEGIN
         ) AS evidenceLines
 
       FROM `{S}.gks_rcv_priority_agg` agg
-      LEFT JOIN `{P}.temp_rcv_condition_data` rcd ON rcd.rcv_accession = agg.rcv_accession
       LEFT JOIN `clinvar_ingest.submission_level` sl ON agg.submission_level = sl.code
-      LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
     """, '{S}', rec.schema_name);
     SET query_priority = REPLACE(query_priority, '{CT}', temp_create);
     SET query_priority = REPLACE(query_priority, '{P}', IF(debug, rec.schema_name, '_SESSION'));
@@ -290,27 +247,7 @@ BEGIN
           ) AS extension
         ) AS classification_mappableConcept,
 
-        STRUCT(
-          cpt.gks_type AS type,
-          agg.prop_id AS id,
-          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
-          CASE cpt.gks_type
-            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
-            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
-            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
-            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
-            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
-            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
-            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
-            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
-            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
-            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
-            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
-            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
-            ELSE 'isClinvarUndefinedAssociationFor'
-          END AS predicate,
-          rcd.condition_concept AS objectCondition
-        ) AS proposition,
+        FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
 
         IF(
           agg.aggregate_review_status IS NOT NULL,
@@ -341,8 +278,6 @@ BEGIN
         ) AS evidenceLines
 
       FROM `{S}.gks_rcv_aggregate_contribution` agg
-      LEFT JOIN `{P}.temp_rcv_condition_data` rcd ON rcd.rcv_accession = agg.rcv_accession
-      LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
     """, '{S}', rec.schema_name);
     SET query_agg_contribution = REPLACE(query_agg_contribution, '{CT}', temp_create);
     SET query_agg_contribution = REPLACE(query_agg_contribution, '{P}', IF(debug, rec.schema_name, '_SESSION'));
@@ -495,6 +430,97 @@ BEGIN
     SET query_agg_contribution_pre = REPLACE(query_agg_contribution_pre, '{CT}', temp_create);
     SET query_agg_contribution_pre = REPLACE(query_agg_contribution_pre, '{P}', IF(debug, rec.schema_name, '_SESSION'));
     EXECUTE IMMEDIATE query_agg_contribution_pre;
+
+    -------------------------------------------------------------------------
+    -- Dictionary table - RCV propositions (global, keyed by proposition id)
+    -- Collects propositions from all 3 layers (classification, priority, agg)
+    -------------------------------------------------------------------------
+    SET dict_rcv_proposition_query = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_rcv_proposition`
+      AS
+      SELECT
+        agg.prop_id as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          cpt.gks_type AS type,
+          agg.prop_id AS id,
+          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
+          CASE cpt.gks_type
+            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
+            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
+            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
+            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
+            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
+            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
+            ELSE 'isClinvarUndefinedAssociationFor'
+          END AS predicate,
+          rcd.condition_concept AS objectCondition
+        )), remove_empty => TRUE) as value
+      FROM `{S}.gks_rcv_classification_agg` agg
+      LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
+      LEFT JOIN {P}.temp_rcv_condition_data rcd ON rcd.rcv_accession = agg.rcv_accession
+      UNION ALL
+      SELECT
+        agg.prop_id as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          cpt.gks_type AS type,
+          agg.prop_id AS id,
+          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
+          CASE cpt.gks_type
+            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
+            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
+            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
+            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
+            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
+            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
+            ELSE 'isClinvarUndefinedAssociationFor'
+          END AS predicate,
+          rcd.condition_concept AS objectCondition
+        )), remove_empty => TRUE) as value
+      FROM `{S}.gks_rcv_priority_agg` agg
+      LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
+      LEFT JOIN {P}.temp_rcv_condition_data rcd ON rcd.rcv_accession = agg.rcv_accession
+      UNION ALL
+      SELECT
+        agg.prop_id as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          cpt.gks_type AS type,
+          agg.prop_id AS id,
+          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
+          CASE cpt.gks_type
+            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
+            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
+            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
+            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
+            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
+            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
+            ELSE 'isClinvarUndefinedAssociationFor'
+          END AS predicate,
+          rcd.condition_concept AS objectCondition
+        )), remove_empty => TRUE) as value
+      FROM `{S}.gks_rcv_aggregate_contribution` agg
+      LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
+      LEFT JOIN {P}.temp_rcv_condition_data rcd ON rcd.rcv_accession = agg.rcv_accession
+    """, '{S}', rec.schema_name);
+    SET dict_rcv_proposition_query = REPLACE(dict_rcv_proposition_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE dict_rcv_proposition_query;
 
     -------------------------------------------------------------------------
     -- FINAL: RCV statement pre (all Aggregate Contribution statements)

--- a/src/procedures/gks-rcv-statement-proc.sql
+++ b/src/procedures/gks-rcv-statement-proc.sql
@@ -88,8 +88,11 @@ BEGIN
         IF(ARRAY_LENGTH(agg.full_scv_ids) = 1,
           agg.scv_strength_name,
           CASE
-            WHEN agg.actual_agg_classif_label IN ('Pathogenic', 'Benign') THEN 'definitive'
-            WHEN agg.actual_agg_classif_label IN ('Likely pathogenic', 'Likely benign') THEN 'likely'
+            WHEN agg.actual_agg_classif_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'definitive'
+            WHEN agg.actual_agg_classif_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'likely'
+            WHEN agg.actual_agg_classif_label LIKE 'Tier I%' THEN 'strong'
+            WHEN agg.actual_agg_classif_label LIKE 'Tier II%' THEN 'potential'
+            WHEN agg.actual_agg_classif_label LIKE 'Tier IV%' THEN 'likely'
             ELSE CAST(NULL AS STRING)
           END
         ) AS strength,
@@ -154,8 +157,11 @@ BEGIN
         END AS direction,
 
         CASE
-          WHEN agg.agg_label IN ('Pathogenic', 'Benign') THEN 'definitive'
-          WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign') THEN 'likely'
+          WHEN agg.agg_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'definitive'
+          WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'likely'
+          WHEN agg.agg_label LIKE 'Tier I%' THEN 'strong'
+          WHEN agg.agg_label LIKE 'Tier II%' THEN 'potential'
+          WHEN agg.agg_label LIKE 'Tier IV%' THEN 'likely'
           ELSE CAST(NULL AS STRING)
         END AS strength,
 
@@ -230,8 +236,11 @@ BEGIN
         END AS direction,
 
         CASE
-          WHEN agg.agg_label IN ('Pathogenic', 'Benign') THEN 'definitive'
-          WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign') THEN 'likely'
+          WHEN agg.agg_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'definitive'
+          WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'likely'
+          WHEN agg.agg_label LIKE 'Tier I%' THEN 'strong'
+          WHEN agg.agg_label LIKE 'Tier II%' THEN 'potential'
+          WHEN agg.agg_label LIKE 'Tier IV%' THEN 'likely'
           ELSE CAST(NULL AS STRING)
         END AS strength,
 

--- a/src/procedures/gks-rcv-statement-proc.sql
+++ b/src/procedures/gks-rcv-statement-proc.sql
@@ -116,7 +116,7 @@ BEGIN
           agg.aggregate_review_status IS NOT NULL,
           [STRUCT('clinvarReviewStatus' AS name, agg.aggregate_review_status AS value)],
           CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-        ) AS extensionss,
+        ) AS extensions,
 
         [
           STRUCT(
@@ -183,7 +183,7 @@ BEGIN
           agg.aggregate_review_status IS NOT NULL,
           [STRUCT('clinvarReviewStatus' AS name, agg.aggregate_review_status AS value)],
           CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-        ) AS extensionss,
+        ) AS extensions,
 
         ARRAY(
           SELECT AS STRUCT val.* FROM UNNEST([
@@ -262,7 +262,7 @@ BEGIN
           agg.aggregate_review_status IS NOT NULL,
           [STRUCT('clinvarReviewStatus' AS name, agg.aggregate_review_status AS value)],
           CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-        ) AS extensionss,
+        ) AS extensions,
 
         ARRAY(
           SELECT AS STRUCT val.* FROM UNNEST([

--- a/src/procedures/gks-rcv-statement-proc.sql
+++ b/src/procedures/gks-rcv-statement-proc.sql
@@ -105,7 +105,7 @@ BEGIN
             [STRUCT('conflictingExplanation' AS name, agg.agg_label_conflicting_explanation AS value)],
             CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
           ) AS extension
-        ) AS classification_mappableConcept,
+        ) AS classification,
 
         FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
 
@@ -169,7 +169,7 @@ BEGIN
             [STRUCT('conflictingExplanation' AS name, agg.agg_label_conflicting_explanation AS value)],
             CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
           ) AS extension
-        ) AS classification_mappableConcept,
+        ) AS classification,
 
         FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
 
@@ -245,7 +245,7 @@ BEGIN
             [STRUCT('conflictingExplanation' AS name, agg.agg_label_conflicting_explanation AS value)],
             CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
           ) AS extension
-        ) AS classification_mappableConcept,
+        ) AS classification,
 
         FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
 
@@ -291,7 +291,7 @@ BEGIN
       {CT} `{P}.temp_rcv_classification_pre` AS
       SELECT
         l1.id, l1.type, l1.direction, l1.strength, l1.confidence,
-        l1.classification_mappableConcept,
+        l1.classification,
         l1.proposition,
         l1.extensions,
         [
@@ -321,7 +321,7 @@ BEGIN
       l2_contributing AS (
         SELECT l2.id, ARRAY_AGG(TO_JSON(
           STRUCT(l1.type, l1.id, l1.direction, l1.strength, l1.confidence,
-            l1.classification_mappableConcept,
+            l1.classification,
             l1.proposition, l1.extensions, l1.evidenceLines)
         )) AS evidenceItems
         FROM `{P}.temp_rcv_priority_statements` l2
@@ -334,7 +334,7 @@ BEGIN
       l2_non_contributing AS (
         SELECT l2.id, ARRAY_AGG(TO_JSON(
           STRUCT(l1.type, l1.id, l1.direction, l1.strength, l1.confidence,
-            l1.classification_mappableConcept,
+            l1.classification,
             l1.proposition, l1.extensions, l1.evidenceLines)
         )) AS evidenceItems
         FROM `{P}.temp_rcv_priority_statements` l2
@@ -346,7 +346,7 @@ BEGIN
       )
       SELECT
         l2.id, l2.type, l2.direction, l2.strength, l2.confidence,
-        l2.classification_mappableConcept,
+        l2.classification,
         l2.proposition,
         l2.extensions,
         ARRAY_CONCAT(
@@ -375,17 +375,17 @@ BEGIN
       WITH
       all_layer_statements AS (
         SELECT id, type, direction, strength, confidence,
-          classification_mappableConcept, proposition, extensions, TO_JSON(evidenceLines) as evidenceLines
+          classification, proposition, extensions, TO_JSON(evidenceLines) as evidenceLines
         FROM `{P}.temp_rcv_priority_pre`
         UNION ALL
         SELECT id, type, direction, strength, confidence,
-          classification_mappableConcept, proposition, extensions, TO_JSON(evidenceLines) as evidenceLines
+          classification, proposition, extensions, TO_JSON(evidenceLines) as evidenceLines
         FROM `{P}.temp_rcv_classification_pre`
       ),
       l3_contributing AS (
         SELECT l3.id, ARRAY_AGG(TO_JSON(
           STRUCT(als.type, als.id, als.direction, als.strength, als.confidence,
-            als.classification_mappableConcept,
+            als.classification,
             als.proposition, als.extensions, als.evidenceLines)
         )) AS evidenceItems
         FROM `{P}.temp_rcv_agg_contribution_statements` l3
@@ -398,7 +398,7 @@ BEGIN
       l3_non_contributing AS (
         SELECT l3.id, ARRAY_AGG(TO_JSON(
           STRUCT(als.type, als.id, als.direction, als.strength, als.confidence,
-            als.classification_mappableConcept,
+            als.classification,
             als.proposition, als.extensions, als.evidenceLines)
         )) AS evidenceItems
         FROM `{P}.temp_rcv_agg_contribution_statements` l3
@@ -410,7 +410,7 @@ BEGIN
       )
       SELECT
         l3.id, l3.type, l3.direction, l3.strength, l3.confidence,
-        l3.classification_mappableConcept,
+        l3.classification,
         l3.proposition,
         l3.extensions,
         ARRAY_CONCAT(

--- a/src/procedures/gks-rcv-statement-proc.sql
+++ b/src/procedures/gks-rcv-statement-proc.sql
@@ -85,16 +85,19 @@ BEGIN
           END
         ) AS direction,
 
-        IF(ARRAY_LENGTH(agg.full_scv_ids) = 1,
-          agg.scv_strength_name,
-          CASE
-            WHEN agg.actual_agg_classif_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'definitive'
-            WHEN agg.actual_agg_classif_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'likely'
-            WHEN agg.actual_agg_classif_label LIKE 'Tier I%' THEN 'strong'
-            WHEN agg.actual_agg_classif_label LIKE 'Tier II%' THEN 'potential'
-            WHEN agg.actual_agg_classif_label LIKE 'Tier IV%' THEN 'likely'
-            ELSE CAST(NULL AS STRING)
-          END
+        STRUCT(
+          'Strength' AS conceptType,
+          IF(ARRAY_LENGTH(agg.full_scv_ids) = 1,
+            agg.scv_strength_name,
+            CASE
+              WHEN agg.actual_agg_classif_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'Definitive'
+              WHEN agg.actual_agg_classif_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'Likely'
+              WHEN agg.actual_agg_classif_label LIKE 'Tier I%' THEN 'Strong'
+              WHEN agg.actual_agg_classif_label LIKE 'Tier II%' THEN 'Potential'
+              WHEN agg.actual_agg_classif_label LIKE 'Tier IV%' THEN 'Likely'
+              ELSE CAST(NULL AS STRING)
+            END
+          ) AS name
         ) AS strength,
 
         sl.label AS confidence,
@@ -156,14 +159,17 @@ BEGIN
           ELSE 'supports'
         END AS direction,
 
-        CASE
-          WHEN agg.agg_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'definitive'
-          WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'likely'
-          WHEN agg.agg_label LIKE 'Tier I%' THEN 'strong'
-          WHEN agg.agg_label LIKE 'Tier II%' THEN 'potential'
-          WHEN agg.agg_label LIKE 'Tier IV%' THEN 'likely'
-          ELSE CAST(NULL AS STRING)
-        END AS strength,
+        STRUCT(
+          'Strength' AS conceptType,
+          CASE
+            WHEN agg.agg_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'Definitive'
+            WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'Likely'
+            WHEN agg.agg_label LIKE 'Tier I%' THEN 'Strong'
+            WHEN agg.agg_label LIKE 'Tier II%' THEN 'Potential'
+            WHEN agg.agg_label LIKE 'Tier IV%' THEN 'Likely'
+            ELSE CAST(NULL AS STRING)
+          END AS name
+        ) AS strength,
 
         sl.label AS confidence,
 
@@ -235,14 +241,17 @@ BEGIN
           ELSE 'supports'
         END AS direction,
 
-        CASE
-          WHEN agg.agg_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'definitive'
-          WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'likely'
-          WHEN agg.agg_label LIKE 'Tier I%' THEN 'strong'
-          WHEN agg.agg_label LIKE 'Tier II%' THEN 'potential'
-          WHEN agg.agg_label LIKE 'Tier IV%' THEN 'likely'
-          ELSE CAST(NULL AS STRING)
-        END AS strength,
+        STRUCT(
+          'Strength' AS conceptType,
+          CASE
+            WHEN agg.agg_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'Definitive'
+            WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'Likely'
+            WHEN agg.agg_label LIKE 'Tier I%' THEN 'Strong'
+            WHEN agg.agg_label LIKE 'Tier II%' THEN 'Potential'
+            WHEN agg.agg_label LIKE 'Tier IV%' THEN 'Likely'
+            ELSE CAST(NULL AS STRING)
+          END AS name
+        ) AS strength,
 
         agg.contributing_submission_level_label AS confidence,
 

--- a/src/procedures/gks-rcv-statement-proc.sql
+++ b/src/procedures/gks-rcv-statement-proc.sql
@@ -125,7 +125,7 @@ BEGIN
           STRUCT(
             'EvidenceLine' AS type,
             'supports' AS directionOfEvidenceProvided,
-            'contributing' AS strengthOfEvidenceProvided,
+            STRUCT('Strength' AS conceptType, 'Contributing' AS name) AS strengthOfEvidenceProvided,
             ARRAY(
               SELECT FORMAT('#/scv/clinvar.submission:%s', scv_id)
               FROM UNNEST(agg.full_scv_ids) AS scv_id
@@ -196,7 +196,7 @@ BEGIN
             STRUCT(
               'EvidenceLine' AS type,
               'supports' AS directionOfEvidenceProvided,
-              'contributing' AS strengthOfEvidenceProvided,
+              STRUCT('Strength' AS conceptType, 'Contributing' AS name) AS strengthOfEvidenceProvided,
               ARRAY(
                 SELECT FORMAT('#/rcv/%s', stmt_id)
                 FROM UNNEST(agg.contributing_statement_ids) AS stmt_id
@@ -205,14 +205,14 @@ BEGIN
             STRUCT(
               'EvidenceLine' AS type,
               'neutral' AS directionOfEvidenceProvided,
-              'non-contributing' AS strengthOfEvidenceProvided,
+              STRUCT('Strength' AS conceptType, 'Non-contributing' AS name) AS strengthOfEvidenceProvided,
               ARRAY(
                 SELECT FORMAT('#/rcv/%s', stmt_id)
                 FROM UNNEST(agg.non_contributing_statement_ids) AS stmt_id
               ) AS evidenceItems
             )
           ]) AS val
-          WHERE val.strengthOfEvidenceProvided = 'contributing'
+          WHERE val.strengthOfEvidenceProvided.name = 'Contributing'
              OR ARRAY_LENGTH(val.evidenceItems) > 0
         ) AS evidenceLines
 
@@ -278,20 +278,20 @@ BEGIN
             STRUCT(
               'EvidenceLine' AS type,
               'supports' AS directionOfEvidenceProvided,
-              'contributing' AS strengthOfEvidenceProvided,
+              STRUCT('Strength' AS conceptType, 'Contributing' AS name) AS strengthOfEvidenceProvided,
               [FORMAT('#/rcv/%s', agg.contributing_layer_id)] AS evidenceItems
             ),
             STRUCT(
               'EvidenceLine' AS type,
               'neutral' AS directionOfEvidenceProvided,
-              'non-contributing' AS strengthOfEvidenceProvided,
+              STRUCT('Strength' AS conceptType, 'Non-contributing' AS name) AS strengthOfEvidenceProvided,
               ARRAY(
                 SELECT FORMAT('#/rcv/%s', nc.layer_id)
                 FROM UNNEST(agg.non_contributing_details) AS nc
               ) AS evidenceItems
             )
           ]) AS val
-          WHERE val.strengthOfEvidenceProvided = 'contributing'
+          WHERE val.strengthOfEvidenceProvided.name = 'Contributing'
              OR ARRAY_LENGTH(val.evidenceItems) > 0
         ) AS evidenceLines
 
@@ -316,7 +316,7 @@ BEGIN
           STRUCT(
             'EvidenceLine' AS type,
             'supports' AS directionOfEvidenceProvided,
-            'contributing' AS strengthOfEvidenceProvided,
+            STRUCT('Strength' AS conceptType, 'Contributing' AS name) AS strengthOfEvidenceProvided,
             ARRAY(
               SELECT FORMAT('#/scv/clinvar.submission:%s', scv_id)
               FROM UNNEST(agg.full_scv_ids) AS scv_id
@@ -346,7 +346,7 @@ BEGIN
         CROSS JOIN UNNEST(l2.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
         JOIN `{P}.temp_rcv_classification_pre` l1 ON l1.id = REGEXP_EXTRACT(item, r'#/rcv/(.+)')
-        WHERE el.strengthOfEvidenceProvided = 'contributing'
+        WHERE el.strengthOfEvidenceProvided.name = 'Contributing'
         GROUP BY l2.id
       ),
       l2_non_contributing AS (
@@ -359,7 +359,7 @@ BEGIN
         CROSS JOIN UNNEST(l2.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
         JOIN `{P}.temp_rcv_classification_pre` l1 ON l1.id = REGEXP_EXTRACT(item, r'#/rcv/(.+)')
-        WHERE el.strengthOfEvidenceProvided = 'non-contributing'
+        WHERE el.strengthOfEvidenceProvided.name = 'Non-contributing'
         GROUP BY l2.id
       )
       SELECT
@@ -369,12 +369,12 @@ BEGIN
         l2.extensions,
         ARRAY_CONCAT(
           IF(c.evidenceItems IS NOT NULL,
-            [STRUCT('EvidenceLine' AS type, 'supports' AS directionOfEvidenceProvided, 'contributing' AS strengthOfEvidenceProvided, c.evidenceItems AS evidenceItems)],
-            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRING, evidenceItems ARRAY<JSON>>>)
+            [STRUCT('EvidenceLine' AS type, 'supports' AS directionOfEvidenceProvided, STRUCT('Strength' AS conceptType, 'Contributing' AS name) AS strengthOfEvidenceProvided, c.evidenceItems AS evidenceItems)],
+            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRUCT<conceptType STRING, name STRING>, evidenceItems ARRAY<JSON>>>)
           ),
           IF(nc.evidenceItems IS NOT NULL,
-            [STRUCT('EvidenceLine' AS type, 'neutral' AS directionOfEvidenceProvided, 'non-contributing' AS strengthOfEvidenceProvided, nc.evidenceItems AS evidenceItems)],
-            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRING, evidenceItems ARRAY<JSON>>>)
+            [STRUCT('EvidenceLine' AS type, 'neutral' AS directionOfEvidenceProvided, STRUCT('Strength' AS conceptType, 'Non-contributing' AS name) AS strengthOfEvidenceProvided, nc.evidenceItems AS evidenceItems)],
+            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRUCT<conceptType STRING, name STRING>, evidenceItems ARRAY<JSON>>>)
           )
         ) AS evidenceLines
       FROM `{P}.temp_rcv_priority_statements` l2
@@ -410,7 +410,7 @@ BEGIN
         CROSS JOIN UNNEST(l3.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
         JOIN all_layer_statements als ON als.id = REGEXP_EXTRACT(item, r'#/rcv/(.+)')
-        WHERE el.strengthOfEvidenceProvided = 'contributing'
+        WHERE el.strengthOfEvidenceProvided.name = 'Contributing'
         GROUP BY l3.id
       ),
       l3_non_contributing AS (
@@ -423,7 +423,7 @@ BEGIN
         CROSS JOIN UNNEST(l3.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
         JOIN all_layer_statements als ON als.id = REGEXP_EXTRACT(item, r'#/rcv/(.+)')
-        WHERE el.strengthOfEvidenceProvided = 'non-contributing'
+        WHERE el.strengthOfEvidenceProvided.name = 'Non-contributing'
         GROUP BY l3.id
       )
       SELECT
@@ -433,12 +433,12 @@ BEGIN
         l3.extensions,
         ARRAY_CONCAT(
           IF(c.evidenceItems IS NOT NULL,
-            [STRUCT('EvidenceLine' AS type, 'supports' AS directionOfEvidenceProvided, 'contributing' AS strengthOfEvidenceProvided, c.evidenceItems AS evidenceItems)],
-            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRING, evidenceItems ARRAY<JSON>>>)
+            [STRUCT('EvidenceLine' AS type, 'supports' AS directionOfEvidenceProvided, STRUCT('Strength' AS conceptType, 'Contributing' AS name) AS strengthOfEvidenceProvided, c.evidenceItems AS evidenceItems)],
+            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRUCT<conceptType STRING, name STRING>, evidenceItems ARRAY<JSON>>>)
           ),
           IF(nc.evidenceItems IS NOT NULL,
-            [STRUCT('EvidenceLine' AS type, 'neutral' AS directionOfEvidenceProvided, 'non-contributing' AS strengthOfEvidenceProvided, nc.evidenceItems AS evidenceItems)],
-            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRING, evidenceItems ARRAY<JSON>>>)
+            [STRUCT('EvidenceLine' AS type, 'neutral' AS directionOfEvidenceProvided, STRUCT('Strength' AS conceptType, 'Non-contributing' AS name) AS strengthOfEvidenceProvided, nc.evidenceItems AS evidenceItems)],
+            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRUCT<conceptType STRING, name STRING>, evidenceItems ARRAY<JSON>>>)
           )
         ) AS evidenceLines
       FROM `{P}.temp_rcv_agg_contribution_statements` l3

--- a/src/procedures/gks-rcv-statement-proc.sql
+++ b/src/procedures/gks-rcv-statement-proc.sql
@@ -104,7 +104,7 @@ BEGIN
             agg.agg_label_conflicting_explanation IS NOT NULL AND agg.agg_label_conflicting_explanation != '',
             [STRUCT('conflictingExplanation' AS name, agg.agg_label_conflicting_explanation AS value)],
             CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-          ) AS extension
+          ) AS extensions
         ) AS classification,
 
         FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
@@ -113,7 +113,7 @@ BEGIN
           agg.aggregate_review_status IS NOT NULL,
           [STRUCT('clinvarReviewStatus' AS name, agg.aggregate_review_status AS value)],
           CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-        ) AS extensions,
+        ) AS extensionss,
 
         [
           STRUCT(
@@ -168,7 +168,7 @@ BEGIN
             agg.agg_label_conflicting_explanation IS NOT NULL AND agg.agg_label_conflicting_explanation != '',
             [STRUCT('conflictingExplanation' AS name, agg.agg_label_conflicting_explanation AS value)],
             CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-          ) AS extension
+          ) AS extensions
         ) AS classification,
 
         FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
@@ -177,7 +177,7 @@ BEGIN
           agg.aggregate_review_status IS NOT NULL,
           [STRUCT('clinvarReviewStatus' AS name, agg.aggregate_review_status AS value)],
           CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-        ) AS extensions,
+        ) AS extensionss,
 
         ARRAY(
           SELECT AS STRUCT val.* FROM UNNEST([
@@ -244,7 +244,7 @@ BEGIN
             agg.agg_label_conflicting_explanation IS NOT NULL AND agg.agg_label_conflicting_explanation != '',
             [STRUCT('conflictingExplanation' AS name, agg.agg_label_conflicting_explanation AS value)],
             CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-          ) AS extension
+          ) AS extensions
         ) AS classification,
 
         FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
@@ -253,7 +253,7 @@ BEGIN
           agg.aggregate_review_status IS NOT NULL,
           [STRUCT('clinvarReviewStatus' AS name, agg.aggregate_review_status AS value)],
           CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-        ) AS extensions,
+        ) AS extensionss,
 
         ARRAY(
           SELECT AS STRUCT val.* FROM UNNEST([

--- a/src/procedures/gks-scv-statement-proc.sql
+++ b/src/procedures/gks-scv-statement-proc.sql
@@ -10,6 +10,8 @@ BEGIN
   DECLARE query_scv_condition_names STRING;
   DECLARE query_scv_citations STRING;
   DECLARE query_scv_method STRING;
+  DECLARE dict_submitter_query STRING;
+  DECLARE dict_proposition_query STRING;
   DECLARE query_statement_scv_pre STRING;
   DECLARE temp_create STRING;
   DECLARE temp_prefix STRING;
@@ -587,6 +589,44 @@ BEGIN
     SET query_scv_method = REPLACE(query_scv_method, '{CT}', temp_create);
     SET query_scv_method = REPLACE(query_scv_method, '{P}', IF(debug, rec.schema_name, '_SESSION'));
     EXECUTE IMMEDIATE query_scv_method;
+
+    ---------------------------------------------------------------------------
+    -- Step 7d: Dictionary table - submitters (global, keyed by clinvar.submitter:{id})
+    ---------------------------------------------------------------------------
+    SET dict_submitter_query = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_submitter`
+      AS
+      SELECT DISTINCT
+        scv.submitter.id as key,
+        JSON_STRIP_NULLS(TO_JSON(scv.submitter), remove_empty => TRUE) as value
+      FROM {P}.temp_gks_scv scv
+      WHERE scv.submitter.id IS NOT NULL
+    """, '{S}', rec.schema_name);
+    SET dict_submitter_query = REPLACE(dict_submitter_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE dict_submitter_query;
+
+    ---------------------------------------------------------------------------
+    -- Step 7e: Dictionary table - propositions (global, keyed by proposition id)
+    ---------------------------------------------------------------------------
+    SET dict_proposition_query = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_proposition`
+      AS
+      SELECT
+        sp.id as key,
+        JSON_STRIP_NULLS(TO_JSON(
+          (SELECT AS STRUCT sp.* EXCEPT(scv_id))
+        ), remove_empty => TRUE) as value
+      FROM {P}.temp_gks_scv_proposition sp
+      UNION ALL
+      SELECT
+        stp.id as key,
+        JSON_STRIP_NULLS(TO_JSON(
+          (SELECT AS STRUCT stp.* EXCEPT(scv_id))
+        ), remove_empty => TRUE) as value
+      FROM {P}.temp_gks_scv_target_proposition stp
+    """, '{S}', rec.schema_name);
+    SET dict_proposition_query = REPLACE(dict_proposition_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE dict_proposition_query;
 
     ---------------------------------------------------------------------------
     -- Step 8: Create statement SCV pre table (simple join, no UNNEST)

--- a/src/procedures/gks-scv-statement-proc.sql
+++ b/src/procedures/gks-scv-statement-proc.sql
@@ -674,6 +674,7 @@ BEGIN
         'Statement' as type,
         FORMAT('#/proposition/%s', sp.id) as proposition,
         STRUCT(
+          'Classification' AS conceptType,
           scv.submitted_classification as name,
           IF(
             scv.classification_code IS NOT NULL,

--- a/src/procedures/gks-scv-statement-proc.sql
+++ b/src/procedures/gks-scv-statement-proc.sql
@@ -596,11 +596,12 @@ BEGIN
     SET dict_submitter_query = REPLACE("""
       CREATE OR REPLACE TABLE `{S}.gks_dict_submitter`
       AS
-      SELECT DISTINCT
+      SELECT
         scv.submitter.id as key,
-        JSON_STRIP_NULLS(TO_JSON(scv.submitter), remove_empty => TRUE) as value
+        ANY_VALUE(JSON_STRIP_NULLS(TO_JSON(scv.submitter), remove_empty => TRUE)) as value
       FROM {P}.temp_gks_scv scv
       WHERE scv.submitter.id IS NOT NULL
+      GROUP BY scv.submitter.id
     """, '{S}', rec.schema_name);
     SET dict_submitter_query = REPLACE(dict_submitter_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
     EXECUTE IMMEDIATE dict_submitter_query;

--- a/src/procedures/gks-scv-statement-proc.sql
+++ b/src/procedures/gks-scv-statement-proc.sql
@@ -764,11 +764,11 @@ BEGIN
               'supports' as directionOfEvidenceProvided,
               CASE scv.classification_code
                 WHEN 'tier 1' THEN
-                  STRUCT('Level A/B' as name)
+                  STRUCT('Classification' as conceptType, 'Level A/B' as name)
                 WHEN 'tier 2' THEN
-                  STRUCT('Level C/D' as name)
+                  STRUCT('Classification' as conceptType, 'Level C/D' as name)
                 ELSE
-                  STRUCT(scv.classification_code as name)
+                  STRUCT('Classification' as conceptType, scv.classification_code as name)
               END as evidenceOutcome,
               IF(
                 spc.extensions.value_submitted_condition_set IS NOT NULL,

--- a/src/procedures/gks-scv-statement-proc.sql
+++ b/src/procedures/gks-scv-statement-proc.sql
@@ -764,11 +764,11 @@ BEGIN
               'supports' as directionOfEvidenceProvided,
               CASE scv.classification_code
                 WHEN 'tier 1' THEN
-                  STRUCT('Classification' as conceptType, 'Level A/B' as name)
+                  STRUCT('Outcome' as conceptType, 'Level A/B' as name)
                 WHEN 'tier 2' THEN
-                  STRUCT('Classification' as conceptType, 'Level C/D' as name)
+                  STRUCT('Outcome' as conceptType, 'Level C/D' as name)
                 ELSE
-                  STRUCT('Classification' as conceptType, scv.classification_code as name)
+                  STRUCT('Outcome' as conceptType, scv.classification_code as name)
               END as evidenceOutcome,
               IF(
                 spc.extensions.value_submitted_condition_set IS NOT NULL,

--- a/src/procedures/gks-scv-statement-proc.sql
+++ b/src/procedures/gks-scv-statement-proc.sql
@@ -691,6 +691,7 @@ BEGIN
           )] AS extensions
         ) as classification,
          STRUCT(
+          'Strength' AS conceptType,
           scv.strength_name as name,
           IF(
             scv.strength_code IS NOT NULL,

--- a/src/procedures/gks-vcv-statement-proc.sql
+++ b/src/procedures/gks-vcv-statement-proc.sql
@@ -55,8 +55,11 @@ BEGIN
         IF(ARRAY_LENGTH(agg.full_scv_ids) = 1,
           agg.scv_strength_name,
           CASE
-            WHEN agg.actual_agg_classif_label IN ('Pathogenic', 'Benign') THEN 'definitive'
-            WHEN agg.actual_agg_classif_label IN ('Likely pathogenic', 'Likely benign') THEN 'likely'
+            WHEN agg.actual_agg_classif_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'definitive'
+            WHEN agg.actual_agg_classif_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'likely'
+            WHEN agg.actual_agg_classif_label LIKE 'Tier I%' THEN 'strong'
+            WHEN agg.actual_agg_classif_label LIKE 'Tier II%' THEN 'potential'
+            WHEN agg.actual_agg_classif_label LIKE 'Tier IV%' THEN 'likely'
             ELSE CAST(NULL AS STRING)
           END
         ) AS strength,
@@ -120,8 +123,11 @@ BEGIN
         END AS direction,
 
         CASE
-          WHEN agg.agg_label IN ('Pathogenic', 'Benign') THEN 'definitive'
-          WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign') THEN 'likely'
+          WHEN agg.agg_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'definitive'
+          WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'likely'
+          WHEN agg.agg_label LIKE 'Tier I%' THEN 'strong'
+          WHEN agg.agg_label LIKE 'Tier II%' THEN 'potential'
+          WHEN agg.agg_label LIKE 'Tier IV%' THEN 'likely'
           ELSE CAST(NULL AS STRING)
         END AS strength,
 
@@ -196,8 +202,11 @@ BEGIN
         END AS direction,
 
         CASE
-          WHEN agg.agg_label IN ('Pathogenic', 'Benign') THEN 'definitive'
-          WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign') THEN 'likely'
+          WHEN agg.agg_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'definitive'
+          WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'likely'
+          WHEN agg.agg_label LIKE 'Tier I%' THEN 'strong'
+          WHEN agg.agg_label LIKE 'Tier II%' THEN 'potential'
+          WHEN agg.agg_label LIKE 'Tier IV%' THEN 'likely'
           ELSE CAST(NULL AS STRING)
         END AS strength,
 

--- a/src/procedures/gks-vcv-statement-proc.sql
+++ b/src/procedures/gks-vcv-statement-proc.sql
@@ -91,7 +91,7 @@ BEGIN
           STRUCT(
             'EvidenceLine' AS type,
             'supports' AS directionOfEvidenceProvided,
-            'contributing' AS strengthOfEvidenceProvided,
+            STRUCT('Strength' AS conceptType, 'Contributing' AS name) AS strengthOfEvidenceProvided,
             ARRAY(
               SELECT FORMAT('#/scv/clinvar.submission:%s', scv_id)
               FROM UNNEST(agg.full_scv_ids) AS scv_id
@@ -162,7 +162,7 @@ BEGIN
             STRUCT(
               'EvidenceLine' AS type,
               'supports' AS directionOfEvidenceProvided,
-              'contributing' AS strengthOfEvidenceProvided,
+              STRUCT('Strength' AS conceptType, 'Contributing' AS name) AS strengthOfEvidenceProvided,
               ARRAY(
                 SELECT FORMAT('#/vcv/%s', stmt_id)
                 FROM UNNEST(agg.contributing_statement_ids) AS stmt_id
@@ -171,14 +171,14 @@ BEGIN
             STRUCT(
               'EvidenceLine' AS type,
               'neutral' AS directionOfEvidenceProvided,
-              'non-contributing' AS strengthOfEvidenceProvided,
+              STRUCT('Strength' AS conceptType, 'Non-contributing' AS name) AS strengthOfEvidenceProvided,
               ARRAY(
                 SELECT FORMAT('#/vcv/%s', stmt_id)
                 FROM UNNEST(agg.non_contributing_statement_ids) AS stmt_id
               ) AS evidenceItems
             )
           ]) AS val
-          WHERE val.strengthOfEvidenceProvided = 'contributing'
+          WHERE val.strengthOfEvidenceProvided.name = 'Contributing'
              OR ARRAY_LENGTH(val.evidenceItems) > 0
         ) AS evidenceLines
 
@@ -244,20 +244,20 @@ BEGIN
             STRUCT(
               'EvidenceLine' AS type,
               'supports' AS directionOfEvidenceProvided,
-              'contributing' AS strengthOfEvidenceProvided,
+              STRUCT('Strength' AS conceptType, 'Contributing' AS name) AS strengthOfEvidenceProvided,
               [FORMAT('#/vcv/%s', agg.contributing_layer_id)] AS evidenceItems
             ),
             STRUCT(
               'EvidenceLine' AS type,
               'neutral' AS directionOfEvidenceProvided,
-              'non-contributing' AS strengthOfEvidenceProvided,
+              STRUCT('Strength' AS conceptType, 'Non-contributing' AS name) AS strengthOfEvidenceProvided,
               ARRAY(
                 SELECT FORMAT('#/vcv/%s', nc.layer_id)
                 FROM UNNEST(agg.non_contributing_details) AS nc
               ) AS evidenceItems
             )
           ]) AS val
-          WHERE val.strengthOfEvidenceProvided = 'contributing'
+          WHERE val.strengthOfEvidenceProvided.name = 'Contributing'
              OR ARRAY_LENGTH(val.evidenceItems) > 0
         ) AS evidenceLines
 
@@ -282,7 +282,7 @@ BEGIN
           STRUCT(
             'EvidenceLine' AS type,
             'supports' AS directionOfEvidenceProvided,
-            'contributing' AS strengthOfEvidenceProvided,
+            STRUCT('Strength' AS conceptType, 'Contributing' AS name) AS strengthOfEvidenceProvided,
             ARRAY(
               SELECT FORMAT('#/scv/clinvar.submission:%s', scv_id)
               FROM UNNEST(agg.full_scv_ids) AS scv_id
@@ -312,7 +312,7 @@ BEGIN
         CROSS JOIN UNNEST(l2.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
         JOIN `{P}.temp_vcv_classification_pre` l1 ON l1.id = REGEXP_EXTRACT(item, r'#/vcv/(.+)')
-        WHERE el.strengthOfEvidenceProvided = 'contributing'
+        WHERE el.strengthOfEvidenceProvided.name = 'Contributing'
         GROUP BY l2.id
       ),
       l2_non_contributing AS (
@@ -325,7 +325,7 @@ BEGIN
         CROSS JOIN UNNEST(l2.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
         JOIN `{P}.temp_vcv_classification_pre` l1 ON l1.id = REGEXP_EXTRACT(item, r'#/vcv/(.+)')
-        WHERE el.strengthOfEvidenceProvided = 'non-contributing'
+        WHERE el.strengthOfEvidenceProvided.name = 'Non-contributing'
         GROUP BY l2.id
       )
       SELECT
@@ -335,12 +335,12 @@ BEGIN
         l2.extensions,
         ARRAY_CONCAT(
           IF(c.evidenceItems IS NOT NULL,
-            [STRUCT('EvidenceLine' AS type, 'supports' AS directionOfEvidenceProvided, 'contributing' AS strengthOfEvidenceProvided, c.evidenceItems AS evidenceItems)],
-            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRING, evidenceItems ARRAY<JSON>>>)
+            [STRUCT('EvidenceLine' AS type, 'supports' AS directionOfEvidenceProvided, STRUCT('Strength' AS conceptType, 'Contributing' AS name) AS strengthOfEvidenceProvided, c.evidenceItems AS evidenceItems)],
+            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRUCT<conceptType STRING, name STRING>, evidenceItems ARRAY<JSON>>>)
           ),
           IF(nc.evidenceItems IS NOT NULL,
-            [STRUCT('EvidenceLine' AS type, 'neutral' AS directionOfEvidenceProvided, 'non-contributing' AS strengthOfEvidenceProvided, nc.evidenceItems AS evidenceItems)],
-            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRING, evidenceItems ARRAY<JSON>>>)
+            [STRUCT('EvidenceLine' AS type, 'neutral' AS directionOfEvidenceProvided, STRUCT('Strength' AS conceptType, 'Non-contributing' AS name) AS strengthOfEvidenceProvided, nc.evidenceItems AS evidenceItems)],
+            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRUCT<conceptType STRING, name STRING>, evidenceItems ARRAY<JSON>>>)
           )
         ) AS evidenceLines
       FROM `{P}.temp_vcv_priority_statements` l2
@@ -376,7 +376,7 @@ BEGIN
         CROSS JOIN UNNEST(l3.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
         JOIN all_layer_statements als ON als.id = REGEXP_EXTRACT(item, r'#/vcv/(.+)')
-        WHERE el.strengthOfEvidenceProvided = 'contributing'
+        WHERE el.strengthOfEvidenceProvided.name = 'Contributing'
         GROUP BY l3.id
       ),
       l3_non_contributing AS (
@@ -389,7 +389,7 @@ BEGIN
         CROSS JOIN UNNEST(l3.evidenceLines) AS el
         CROSS JOIN UNNEST(el.evidenceItems) AS item
         JOIN all_layer_statements als ON als.id = REGEXP_EXTRACT(item, r'#/vcv/(.+)')
-        WHERE el.strengthOfEvidenceProvided = 'non-contributing'
+        WHERE el.strengthOfEvidenceProvided.name = 'Non-contributing'
         GROUP BY l3.id
       )
       SELECT
@@ -399,12 +399,12 @@ BEGIN
         l3.extensions,
         ARRAY_CONCAT(
           IF(c.evidenceItems IS NOT NULL,
-            [STRUCT('EvidenceLine' AS type, 'supports' AS directionOfEvidenceProvided, 'contributing' AS strengthOfEvidenceProvided, c.evidenceItems AS evidenceItems)],
-            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRING, evidenceItems ARRAY<JSON>>>)
+            [STRUCT('EvidenceLine' AS type, 'supports' AS directionOfEvidenceProvided, STRUCT('Strength' AS conceptType, 'Contributing' AS name) AS strengthOfEvidenceProvided, c.evidenceItems AS evidenceItems)],
+            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRUCT<conceptType STRING, name STRING>, evidenceItems ARRAY<JSON>>>)
           ),
           IF(nc.evidenceItems IS NOT NULL,
-            [STRUCT('EvidenceLine' AS type, 'neutral' AS directionOfEvidenceProvided, 'non-contributing' AS strengthOfEvidenceProvided, nc.evidenceItems AS evidenceItems)],
-            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRING, evidenceItems ARRAY<JSON>>>)
+            [STRUCT('EvidenceLine' AS type, 'neutral' AS directionOfEvidenceProvided, STRUCT('Strength' AS conceptType, 'Non-contributing' AS name) AS strengthOfEvidenceProvided, nc.evidenceItems AS evidenceItems)],
+            CAST([] AS ARRAY<STRUCT<type STRING, directionOfEvidenceProvided STRING, strengthOfEvidenceProvided STRUCT<conceptType STRING, name STRING>, evidenceItems ARRAY<JSON>>>)
           )
         ) AS evidenceLines
       FROM `{P}.temp_vcv_agg_contribution_statements` l3

--- a/src/procedures/gks-vcv-statement-proc.sql
+++ b/src/procedures/gks-vcv-statement-proc.sql
@@ -73,27 +73,7 @@ BEGIN
           ) AS extension
         ) AS classification_mappableConcept,
 
-        STRUCT(
-          cpt.gks_type AS type,
-          agg.prop_id AS id,
-          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
-          CASE cpt.gks_type
-            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
-            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
-            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
-            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
-            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
-            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
-            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
-            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
-            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
-            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
-            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
-            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
-            ELSE 'isClinvarUndefinedAssociationFor'
-          END AS predicate,
-          agg.unique_conditions AS objectCondition
-        ) AS proposition,
+        FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
 
         IF(
           agg.aggregate_review_status IS NOT NULL,
@@ -115,7 +95,6 @@ BEGIN
 
       FROM `{S}.gks_vcv_classification_agg` agg
       LEFT JOIN `clinvar_ingest.submission_level` sl ON agg.submission_level = sl.code
-      LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
     """, '{S}', rec.schema_name);
     SET query_classification = REPLACE(query_classification, '{CT}', temp_create);
     SET query_classification = REPLACE(query_classification, '{P}', IF(debug, rec.schema_name, '_SESSION'));
@@ -158,27 +137,7 @@ BEGIN
           ) AS extension
         ) AS classification_mappableConcept,
 
-        STRUCT(
-          cpt.gks_type AS type,
-          agg.prop_id AS id,
-          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
-          CASE cpt.gks_type
-            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
-            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
-            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
-            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
-            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
-            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
-            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
-            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
-            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
-            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
-            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
-            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
-            ELSE 'isClinvarUndefinedAssociationFor'
-          END AS predicate,
-          agg.unique_conditions AS objectCondition
-        ) AS proposition,
+        FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
 
         IF(
           agg.aggregate_review_status IS NOT NULL,
@@ -213,7 +172,6 @@ BEGIN
 
       FROM `{S}.gks_vcv_priority_agg` agg
       LEFT JOIN `clinvar_ingest.submission_level` sl ON agg.submission_level = sl.code
-      LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
     """, '{S}', rec.schema_name);
     SET query_priority = REPLACE(query_priority, '{CT}', temp_create);
     SET query_priority = REPLACE(query_priority, '{P}', IF(debug, rec.schema_name, '_SESSION'));
@@ -255,27 +213,7 @@ BEGIN
           ) AS extension
         ) AS classification_mappableConcept,
 
-        STRUCT(
-          cpt.gks_type AS type,
-          agg.prop_id AS id,
-          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
-          CASE cpt.gks_type
-            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
-            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
-            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
-            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
-            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
-            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
-            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
-            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
-            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
-            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
-            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
-            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
-            ELSE 'isClinvarUndefinedAssociationFor'
-          END AS predicate,
-          agg.unique_conditions AS objectCondition
-        ) AS proposition,
+        FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
 
         IF(
           agg.aggregate_review_status IS NOT NULL,
@@ -306,7 +244,6 @@ BEGIN
         ) AS evidenceLines
 
       FROM `{S}.gks_vcv_aggregate_contribution` agg
-      LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
     """, '{S}', rec.schema_name);
     SET query_agg_contribution = REPLACE(query_agg_contribution, '{CT}', temp_create);
     SET query_agg_contribution = REPLACE(query_agg_contribution, '{P}', IF(debug, rec.schema_name, '_SESSION'));

--- a/src/procedures/gks-vcv-statement-proc.sql
+++ b/src/procedures/gks-vcv-statement-proc.sql
@@ -6,6 +6,7 @@ BEGIN
   DECLARE query_classification_pre STRING;
   DECLARE query_priority_pre STRING;
   DECLARE query_agg_contribution_pre STRING;
+  DECLARE dict_vcv_proposition_query STRING;
   DECLARE query_vcv_pre STRING;
   DECLARE temp_create STRING;
 
@@ -458,6 +459,34 @@ BEGIN
     SET query_agg_contribution_pre = REPLACE(query_agg_contribution_pre, '{CT}', temp_create);
     SET query_agg_contribution_pre = REPLACE(query_agg_contribution_pre, '{P}', IF(debug, rec.schema_name, '_SESSION'));
     EXECUTE IMMEDIATE query_agg_contribution_pre;
+
+    -------------------------------------------------------------------------
+    -- Dictionary table - VCV propositions (global, keyed by proposition id)
+    -- Collects propositions from all 3 layers (classification, priority, agg)
+    -------------------------------------------------------------------------
+    SET dict_vcv_proposition_query = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_vcv_proposition`
+      AS
+      SELECT
+        s.proposition.id as key,
+        ANY_VALUE(JSON_STRIP_NULLS(TO_JSON(s.proposition), remove_empty => TRUE)) as value
+      FROM `{P}.temp_vcv_classification_statements` s
+      GROUP BY s.proposition.id
+      UNION ALL
+      SELECT
+        s.proposition.id as key,
+        ANY_VALUE(JSON_STRIP_NULLS(TO_JSON(s.proposition), remove_empty => TRUE)) as value
+      FROM `{P}.temp_vcv_priority_statements` s
+      GROUP BY s.proposition.id
+      UNION ALL
+      SELECT
+        s.proposition.id as key,
+        ANY_VALUE(JSON_STRIP_NULLS(TO_JSON(s.proposition), remove_empty => TRUE)) as value
+      FROM `{P}.temp_vcv_agg_contribution_statements` s
+      GROUP BY s.proposition.id
+    """, '{S}', rec.schema_name);
+    SET dict_vcv_proposition_query = REPLACE(dict_vcv_proposition_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE dict_vcv_proposition_query;
 
     -------------------------------------------------------------------------
     -- FINAL: VCV statement pre (all Aggregate Contribution statements)

--- a/src/procedures/gks-vcv-statement-proc.sql
+++ b/src/procedures/gks-vcv-statement-proc.sql
@@ -31,7 +31,7 @@ BEGIN
 
     -------------------------------------------------------------------------
     -- GROUPING LAYER: CLASSIFICATION GROUPING
-    -- All submission levels use classification_mappableConcept (no PGEP
+    -- All submission levels use classification (no PGEP
     -- per-SCV expansion).
     -------------------------------------------------------------------------
     SET query_classification = REPLACE("""
@@ -71,7 +71,7 @@ BEGIN
             [STRUCT('conflictingExplanation' AS name, agg.agg_label_conflicting_explanation AS value)],
             CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
           ) AS extension
-        ) AS classification_mappableConcept,
+        ) AS classification,
 
         FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
 
@@ -135,7 +135,7 @@ BEGIN
             [STRUCT('conflictingExplanation' AS name, agg.agg_label_conflicting_explanation AS value)],
             CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
           ) AS extension
-        ) AS classification_mappableConcept,
+        ) AS classification,
 
         FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
 
@@ -211,7 +211,7 @@ BEGIN
             [STRUCT('conflictingExplanation' AS name, agg.agg_label_conflicting_explanation AS value)],
             CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
           ) AS extension
-        ) AS classification_mappableConcept,
+        ) AS classification,
 
         FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
 
@@ -257,7 +257,7 @@ BEGIN
       {CT} `{P}.temp_vcv_classification_pre` AS
       SELECT
         l1.id, l1.type, l1.direction, l1.strength, l1.confidence,
-        l1.classification_mappableConcept,
+        l1.classification,
         l1.proposition,
         l1.extensions,
         [
@@ -287,7 +287,7 @@ BEGIN
       l2_contributing AS (
         SELECT l2.id, ARRAY_AGG(TO_JSON(
           STRUCT(l1.type, l1.id, l1.direction, l1.strength, l1.confidence,
-            l1.classification_mappableConcept,
+            l1.classification,
             l1.proposition, l1.extensions, l1.evidenceLines)
         )) AS evidenceItems
         FROM `{P}.temp_vcv_priority_statements` l2
@@ -300,7 +300,7 @@ BEGIN
       l2_non_contributing AS (
         SELECT l2.id, ARRAY_AGG(TO_JSON(
           STRUCT(l1.type, l1.id, l1.direction, l1.strength, l1.confidence,
-            l1.classification_mappableConcept,
+            l1.classification,
             l1.proposition, l1.extensions, l1.evidenceLines)
         )) AS evidenceItems
         FROM `{P}.temp_vcv_priority_statements` l2
@@ -312,7 +312,7 @@ BEGIN
       )
       SELECT
         l2.id, l2.type, l2.direction, l2.strength, l2.confidence,
-        l2.classification_mappableConcept,
+        l2.classification,
         l2.proposition,
         l2.extensions,
         ARRAY_CONCAT(
@@ -341,17 +341,17 @@ BEGIN
       WITH
       all_layer_statements AS (
         SELECT id, type, direction, strength, confidence,
-          classification_mappableConcept, proposition, extensions, TO_JSON(evidenceLines) as evidenceLines
+          classification, proposition, extensions, TO_JSON(evidenceLines) as evidenceLines
         FROM `{P}.temp_vcv_priority_pre`
         UNION ALL
         SELECT id, type, direction, strength, confidence,
-          classification_mappableConcept, proposition, extensions, TO_JSON(evidenceLines) as evidenceLines
+          classification, proposition, extensions, TO_JSON(evidenceLines) as evidenceLines
         FROM `{P}.temp_vcv_classification_pre`
       ),
       l3_contributing AS (
         SELECT l3.id, ARRAY_AGG(TO_JSON(
           STRUCT(als.type, als.id, als.direction, als.strength, als.confidence,
-            als.classification_mappableConcept,
+            als.classification,
             als.proposition, als.extensions, als.evidenceLines)
         )) AS evidenceItems
         FROM `{P}.temp_vcv_agg_contribution_statements` l3
@@ -364,7 +364,7 @@ BEGIN
       l3_non_contributing AS (
         SELECT l3.id, ARRAY_AGG(TO_JSON(
           STRUCT(als.type, als.id, als.direction, als.strength, als.confidence,
-            als.classification_mappableConcept,
+            als.classification,
             als.proposition, als.extensions, als.evidenceLines)
         )) AS evidenceItems
         FROM `{P}.temp_vcv_agg_contribution_statements` l3
@@ -376,7 +376,7 @@ BEGIN
       )
       SELECT
         l3.id, l3.type, l3.direction, l3.strength, l3.confidence,
-        l3.classification_mappableConcept,
+        l3.classification,
         l3.proposition,
         l3.extensions,
         ARRAY_CONCAT(

--- a/src/procedures/gks-vcv-statement-proc.sql
+++ b/src/procedures/gks-vcv-statement-proc.sql
@@ -405,22 +405,82 @@ BEGIN
       CREATE OR REPLACE TABLE `{S}.gks_dict_vcv_proposition`
       AS
       SELECT
-        s.proposition.id as key,
-        ANY_VALUE(JSON_STRIP_NULLS(TO_JSON(s.proposition), remove_empty => TRUE)) as value
-      FROM `{P}.temp_vcv_classification_statements` s
-      GROUP BY s.proposition.id
+        agg.prop_id as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          cpt.gks_type AS type,
+          agg.prop_id AS id,
+          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
+          CASE cpt.gks_type
+            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
+            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
+            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
+            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
+            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
+            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
+            ELSE 'isClinvarUndefinedAssociationFor'
+          END AS predicate,
+          agg.unique_conditions AS objectCondition
+        )), remove_empty => TRUE) as value
+      FROM `{S}.gks_vcv_classification_agg` agg
+      LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
       UNION ALL
       SELECT
-        s.proposition.id as key,
-        ANY_VALUE(JSON_STRIP_NULLS(TO_JSON(s.proposition), remove_empty => TRUE)) as value
-      FROM `{P}.temp_vcv_priority_statements` s
-      GROUP BY s.proposition.id
+        agg.prop_id as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          cpt.gks_type AS type,
+          agg.prop_id AS id,
+          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
+          CASE cpt.gks_type
+            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
+            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
+            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
+            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
+            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
+            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
+            ELSE 'isClinvarUndefinedAssociationFor'
+          END AS predicate,
+          agg.unique_conditions AS objectCondition
+        )), remove_empty => TRUE) as value
+      FROM `{S}.gks_vcv_priority_agg` agg
+      LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
       UNION ALL
       SELECT
-        s.proposition.id as key,
-        ANY_VALUE(JSON_STRIP_NULLS(TO_JSON(s.proposition), remove_empty => TRUE)) as value
-      FROM `{P}.temp_vcv_agg_contribution_statements` s
-      GROUP BY s.proposition.id
+        agg.prop_id as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          cpt.gks_type AS type,
+          agg.prop_id AS id,
+          FORMAT('#/variation/clinvar:%s', agg.variation_id) AS subjectVariant,
+          CASE cpt.gks_type
+            WHEN 'VariantPathogenicityProposition' THEN 'isCausalFor'
+            WHEN 'VariantOncogenicityProposition' THEN 'isOncogenicFor'
+            WHEN 'VariantClinicalSignificanceProposition' THEN 'isClinicallySignificantFor'
+            WHEN 'ClinvarAffectsProposition' THEN 'hasAffectFor'
+            WHEN 'ClinvarAssociationProposition' THEN 'isAssociatedWith'
+            WHEN 'ClinvarConfersSensitivityProposition' THEN 'confersSensitivityFor'
+            WHEN 'ClinvarConflictingDataFromSubmitterProposition' THEN 'isConflictingDataFromSubmittersFor'
+            WHEN 'ClinvarDrugResponseProposition' THEN 'hasDrugResponseFor'
+            WHEN 'ClinvarNotProvidedProposition' THEN 'hasNoProvidedClassificationFor'
+            WHEN 'ClinvarOtherProposition' THEN 'isClinvarOtherAssociationFor'
+            WHEN 'ClinvarProtectiveProposition' THEN 'isProtectiveFor'
+            WHEN 'ClinvarRiskFactorProposition' THEN 'isRiskFactorFor'
+            ELSE 'isClinvarUndefinedAssociationFor'
+          END AS predicate,
+          agg.unique_conditions AS objectCondition
+        )), remove_empty => TRUE) as value
+      FROM `{S}.gks_vcv_aggregate_contribution` agg
+      LEFT JOIN `clinvar_ingest.clinvar_proposition_types` cpt ON agg.prop_type = cpt.code
     """, '{S}', rec.schema_name);
     SET dict_vcv_proposition_query = REPLACE(dict_vcv_proposition_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
     EXECUTE IMMEDIATE dict_vcv_proposition_query;

--- a/src/procedures/gks-vcv-statement-proc.sql
+++ b/src/procedures/gks-vcv-statement-proc.sql
@@ -70,7 +70,7 @@ BEGIN
             agg.agg_label_conflicting_explanation IS NOT NULL AND agg.agg_label_conflicting_explanation != '',
             [STRUCT('conflictingExplanation' AS name, agg.agg_label_conflicting_explanation AS value)],
             CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-          ) AS extension
+          ) AS extensions
         ) AS classification,
 
         FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
@@ -79,7 +79,7 @@ BEGIN
           agg.aggregate_review_status IS NOT NULL,
           [STRUCT('clinvarReviewStatus' AS name, agg.aggregate_review_status AS value)],
           CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-        ) AS extensions,
+        ) AS extensionss,
 
         [
           STRUCT(
@@ -134,7 +134,7 @@ BEGIN
             agg.agg_label_conflicting_explanation IS NOT NULL AND agg.agg_label_conflicting_explanation != '',
             [STRUCT('conflictingExplanation' AS name, agg.agg_label_conflicting_explanation AS value)],
             CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-          ) AS extension
+          ) AS extensions
         ) AS classification,
 
         FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
@@ -143,7 +143,7 @@ BEGIN
           agg.aggregate_review_status IS NOT NULL,
           [STRUCT('clinvarReviewStatus' AS name, agg.aggregate_review_status AS value)],
           CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-        ) AS extensions,
+        ) AS extensionss,
 
         ARRAY(
           SELECT AS STRUCT val.* FROM UNNEST([
@@ -210,7 +210,7 @@ BEGIN
             agg.agg_label_conflicting_explanation IS NOT NULL AND agg.agg_label_conflicting_explanation != '',
             [STRUCT('conflictingExplanation' AS name, agg.agg_label_conflicting_explanation AS value)],
             CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-          ) AS extension
+          ) AS extensions
         ) AS classification,
 
         FORMAT('#/proposition/%s', agg.prop_id) AS proposition,
@@ -219,7 +219,7 @@ BEGIN
           agg.aggregate_review_status IS NOT NULL,
           [STRUCT('clinvarReviewStatus' AS name, agg.aggregate_review_status AS value)],
           CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-        ) AS extensions,
+        ) AS extensionss,
 
         ARRAY(
           SELECT AS STRUCT val.* FROM UNNEST([

--- a/src/procedures/gks-vcv-statement-proc.sql
+++ b/src/procedures/gks-vcv-statement-proc.sql
@@ -82,7 +82,7 @@ BEGIN
           agg.aggregate_review_status IS NOT NULL,
           [STRUCT('clinvarReviewStatus' AS name, agg.aggregate_review_status AS value)],
           CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-        ) AS extensionss,
+        ) AS extensions,
 
         [
           STRUCT(
@@ -149,7 +149,7 @@ BEGIN
           agg.aggregate_review_status IS NOT NULL,
           [STRUCT('clinvarReviewStatus' AS name, agg.aggregate_review_status AS value)],
           CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-        ) AS extensionss,
+        ) AS extensions,
 
         ARRAY(
           SELECT AS STRUCT val.* FROM UNNEST([
@@ -228,7 +228,7 @@ BEGIN
           agg.aggregate_review_status IS NOT NULL,
           [STRUCT('clinvarReviewStatus' AS name, agg.aggregate_review_status AS value)],
           CAST(NULL AS ARRAY<STRUCT<name STRING, value STRING>>)
-        ) AS extensionss,
+        ) AS extensions,
 
         ARRAY(
           SELECT AS STRUCT val.* FROM UNNEST([

--- a/src/procedures/gks-vcv-statement-proc.sql
+++ b/src/procedures/gks-vcv-statement-proc.sql
@@ -52,16 +52,19 @@ BEGIN
           END
         ) AS direction,
 
-        IF(ARRAY_LENGTH(agg.full_scv_ids) = 1,
-          agg.scv_strength_name,
-          CASE
-            WHEN agg.actual_agg_classif_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'definitive'
-            WHEN agg.actual_agg_classif_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'likely'
-            WHEN agg.actual_agg_classif_label LIKE 'Tier I%' THEN 'strong'
-            WHEN agg.actual_agg_classif_label LIKE 'Tier II%' THEN 'potential'
-            WHEN agg.actual_agg_classif_label LIKE 'Tier IV%' THEN 'likely'
-            ELSE CAST(NULL AS STRING)
-          END
+        STRUCT(
+          'Strength' AS conceptType,
+          IF(ARRAY_LENGTH(agg.full_scv_ids) = 1,
+            agg.scv_strength_name,
+            CASE
+              WHEN agg.actual_agg_classif_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'Definitive'
+              WHEN agg.actual_agg_classif_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'Likely'
+              WHEN agg.actual_agg_classif_label LIKE 'Tier I%' THEN 'Strong'
+              WHEN agg.actual_agg_classif_label LIKE 'Tier II%' THEN 'Potential'
+              WHEN agg.actual_agg_classif_label LIKE 'Tier IV%' THEN 'Likely'
+              ELSE CAST(NULL AS STRING)
+            END
+          ) AS name
         ) AS strength,
 
         sl.label AS confidence,
@@ -122,14 +125,17 @@ BEGIN
           ELSE 'supports'
         END AS direction,
 
-        CASE
-          WHEN agg.agg_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'definitive'
-          WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'likely'
-          WHEN agg.agg_label LIKE 'Tier I%' THEN 'strong'
-          WHEN agg.agg_label LIKE 'Tier II%' THEN 'potential'
-          WHEN agg.agg_label LIKE 'Tier IV%' THEN 'likely'
-          ELSE CAST(NULL AS STRING)
-        END AS strength,
+        STRUCT(
+          'Strength' AS conceptType,
+          CASE
+            WHEN agg.agg_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'Definitive'
+            WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'Likely'
+            WHEN agg.agg_label LIKE 'Tier I%' THEN 'Strong'
+            WHEN agg.agg_label LIKE 'Tier II%' THEN 'Potential'
+            WHEN agg.agg_label LIKE 'Tier IV%' THEN 'Likely'
+            ELSE CAST(NULL AS STRING)
+          END AS name
+        ) AS strength,
 
         sl.label AS confidence,
 
@@ -201,14 +207,17 @@ BEGIN
           ELSE 'supports'
         END AS direction,
 
-        CASE
-          WHEN agg.agg_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'definitive'
-          WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'likely'
-          WHEN agg.agg_label LIKE 'Tier I%' THEN 'strong'
-          WHEN agg.agg_label LIKE 'Tier II%' THEN 'potential'
-          WHEN agg.agg_label LIKE 'Tier IV%' THEN 'likely'
-          ELSE CAST(NULL AS STRING)
-        END AS strength,
+        STRUCT(
+          'Strength' AS conceptType,
+          CASE
+            WHEN agg.agg_label IN ('Pathogenic', 'Benign', 'Oncogenic') THEN 'Definitive'
+            WHEN agg.agg_label IN ('Likely pathogenic', 'Likely benign', 'Likely Oncogenic') THEN 'Likely'
+            WHEN agg.agg_label LIKE 'Tier I%' THEN 'Strong'
+            WHEN agg.agg_label LIKE 'Tier II%' THEN 'Potential'
+            WHEN agg.agg_label LIKE 'Tier IV%' THEN 'Likely'
+            ELSE CAST(NULL AS STRING)
+          END AS name
+        ) AS strength,
 
         agg.contributing_submission_level_label AS confidence,
 

--- a/src/scripts/assemble-gks-dicts.py
+++ b/src/scripts/assemble-gks-dicts.py
@@ -57,7 +57,7 @@ SECTIONS = [
     ("location", "location-*.ndjson.gz", "key", "value"),
     ("allele", "allele-*.ndjson.gz", "key", "value"),
     ("gene", "gene-*.ndjson.gz", "key", "value"),
-    ("variation", "variation-*.ndjson.gz", "key", "value"),
+    ("variation", "variation-*.ndjson.gz", "id", None),
     ("condition", "condition-*.ndjson.gz", "id", None),
     ("conditionSet", "conditionSet-*.ndjson.gz", "id", None),
     ("submitter", "submitter-*.ndjson.gz", "key", "value"),

--- a/src/scripts/assemble-gks-dicts.py
+++ b/src/scripts/assemble-gks-dicts.py
@@ -2,24 +2,56 @@
 """
 Assemble GKS dictionary NDJSON files into a single keyed JSON file.
 
-Each input file contains rows of {"key": "...", "value": {...}} which are
-assembled into a root-level keyed dictionary per section.
+Supports reading from local files or streaming directly from GCS.
 
 Usage:
-  python3 assemble-gks-dicts.py <input_dir> <output_file>
+  # From local files
+  python3 assemble-gks-dicts.py ./gks-dicts/ ./clinvar-gks.json.gz
 
-Example:
-  python3 assemble-gks-dicts.py ./gks-dicts/ ./clinvar-gks-2025-06-08.json.gz
+  # Stream from GCS (no download needed — run in Cloud Shell for best perf)
+  python3 assemble-gks-dicts.py gs://bucket/gks-dicts/2026-05-10/ ./clinvar-gks.json.gz
+
+  # Stream from GCS and upload result to GCS
+  python3 assemble-gks-dicts.py gs://bucket/gks-dicts/2026-05-10/ gs://bucket/release/clinvar-gks.json.gz
+
+Dependencies:
+  pip install orjson  # optional, 10-50x faster JSON; falls back to stdlib json
 """
 import gzip
-import json
+import io
+import subprocess
 import sys
+import time
+from fnmatch import fnmatch
 from pathlib import Path
+
+try:
+    import orjson
+
+    def json_loads(s):
+        return orjson.loads(s)
+
+    def json_dumps_key(key):
+        return orjson.dumps(key).decode()
+
+    def json_dumps_value(value):
+        return orjson.dumps(value).decode()
+
+except ImportError:
+    import json
+
+    def json_loads(s):
+        return json.loads(s)
+
+    def json_dumps_key(key):
+        return json.dumps(key)
+
+    def json_dumps_value(value):
+        return json.dumps(value, separators=(",", ":"))
 
 
 # Dictionary sections in output order.
 # Each tuple is (section_name, glob_pattern, key_field, value_field).
-# Glob patterns match sharded exports (e.g., allele-*.ndjson.gz).
 SECTIONS = [
     ("sequenceReference", "sequenceReference-*.ndjson.gz", "key", "value"),
     ("location", "location-*.ndjson.gz", "key", "value"),
@@ -37,87 +69,155 @@ SECTIONS = [
     ("rcv", "rcv-*.ndjson.gz", "id", None),
 ]
 
+WRITE_BUFFER_SIZE = 8 * 1024 * 1024  # 8MB write buffer
 
-def open_file(path):
-    """Open a file, handling gzip transparently."""
+
+def list_gcs_files(gcs_prefix):
+    """List files in a GCS prefix using gcloud storage."""
+    result = subprocess.run(
+        ["gcloud", "storage", "ls", gcs_prefix],
+        capture_output=True, text=True, check=True,
+    )
+    return [line.strip() for line in result.stdout.strip().split("\n") if line.strip()]
+
+
+def open_gcs_file(gcs_path):
+    """Stream a GCS file through gcloud storage cat, decompressing if gzipped."""
+    proc = subprocess.Popen(
+        ["gcloud", "storage", "cat", gcs_path],
+        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+    )
+    if gcs_path.endswith(".gz"):
+        return io.TextIOWrapper(gzip.open(proc.stdout, "rb"), encoding="utf-8")
+    return io.TextIOWrapper(proc.stdout, encoding="utf-8")
+
+
+def open_local_file(path):
+    """Open a local file, handling gzip transparently."""
     if str(path).endswith(".gz"):
         return gzip.open(path, "rt", encoding="utf-8")
     return open(path, "r", encoding="utf-8")
 
 
-def stream_dict(ndjson_path, key_field="key", value_field="value"):
+def resolve_files(source, glob_pattern):
     """
-    Yield (key, value_json_string) pairs from an NDJSON file.
+    Resolve files matching a glob pattern from local dir or GCS prefix.
+    Returns list of (path_or_uri, opener_fn) tuples.
+    """
+    if source.startswith("gs://"):
+        prefix = source.rstrip("/") + "/"
+        all_files = list_gcs_files(prefix)
+        # Match the glob pattern against the filename portion
+        matched = []
+        for uri in all_files:
+            filename = uri.split("/")[-1]
+            if fnmatch(filename, glob_pattern):
+                matched.append(uri)
+        return sorted(matched), open_gcs_file
+    else:
+        local_dir = Path(source)
+        files = sorted(local_dir.glob(glob_pattern))
+        return [str(f) for f in files], open_local_file
 
-    If value_field is None, the entire record (minus the key field) is the value.
-    If value_field is specified and its content is a JSON string, it is parsed.
-    """
-    with open_file(ndjson_path) as f:
+
+def stream_dict(filepath, opener_fn, key_field="key", value_field="value"):
+    """Yield (key, value) pairs from an NDJSON file."""
+    with opener_fn(filepath) as f:
         for line in f:
             line = line.strip()
             if not line:
                 continue
-            rec = json.loads(line)
+            rec = json_loads(line)
             key = rec[key_field]
 
             if value_field is None:
-                # Use the whole record as the value
                 value = rec
             else:
                 raw = rec[value_field]
-                # If the value is a JSON string, parse it
                 if isinstance(raw, str):
-                    value = json.loads(raw)
+                    value = json_loads(raw)
                 else:
                     value = raw
 
             yield key, value
 
 
-def assemble(input_dir, output_path):
-    """Assemble all dictionary NDJSON files into a single keyed JSON file."""
-    input_dir = Path(input_dir)
-    is_gzip = str(output_path).endswith(".gz")
-    opener = gzip.open if is_gzip else open
+def open_output(output_path):
+    """Open output file — supports local or GCS paths."""
+    if output_path.startswith("gs://"):
+        # Pipe through gcloud storage cp
+        proc = subprocess.Popen(
+            ["gcloud", "storage", "cp", "-", output_path],
+            stdin=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        if output_path.endswith(".gz"):
+            return gzip.open(proc.stdin, "wt", encoding="utf-8"), proc
+        return io.TextIOWrapper(proc.stdin, encoding="utf-8"), proc
+    else:
+        is_gzip = output_path.endswith(".gz")
+        opener = gzip.open if is_gzip else open
+        return opener(output_path, "wt", encoding="utf-8"), None
 
+
+def assemble(source, output_path):
+    """Assemble all dictionary NDJSON files into a single keyed JSON file."""
     section_count = 0
     total_entries = 0
+    start_time = time.time()
 
-    with opener(output_path, "wt", encoding="utf-8") as out:
-        out.write("{\n")
+    out, proc = open_output(output_path)
+    buf = io.StringIO()
+
+    try:
+        buf.write("{\n")
 
         first_section = True
         for section_name, glob_pattern, key_field, value_field in SECTIONS:
-            files = sorted(input_dir.glob(glob_pattern))
+            files, opener_fn = resolve_files(source, glob_pattern)
             if not files:
                 print(f"  Skipping {section_name} (no files matching {glob_pattern})")
                 continue
 
             if not first_section:
-                out.write(",\n")
+                buf.write(",\n")
             first_section = False
 
-            print(f"  Assembling {section_name} from {len(files)} file(s)...")
-            out.write(f'  "{section_name}": {{\n')
+            section_start = time.time()
+            print(f"  Assembling {section_name} from {len(files)} file(s)...", end="", flush=True)
+            buf.write(f'  "{section_name}": {{\n')
 
             entry_count = 0
             first_entry = True
             for filepath in files:
-                for key, value in stream_dict(filepath, key_field, value_field):
+                for key, value in stream_dict(filepath, opener_fn, key_field, value_field):
                     if not first_entry:
-                        out.write(",\n")
+                        buf.write(",\n")
                     first_entry = False
-                    out.write(f"    {json.dumps(key)}: {json.dumps(value, separators=(',', ':'))}")
+                    buf.write(f"    {json_dumps_key(key)}: {json_dumps_value(value)}")
                     entry_count += 1
 
-            out.write("\n  }")
+                    # Flush buffer periodically
+                    if buf.tell() >= WRITE_BUFFER_SIZE:
+                        out.write(buf.getvalue())
+                        buf.seek(0)
+                        buf.truncate()
+
+            buf.write("\n  }")
             section_count += 1
             total_entries += entry_count
-            print(f"    -> {entry_count:,} entries")
+            elapsed = time.time() - section_start
+            print(f" {entry_count:,} entries ({elapsed:.1f}s)")
 
-        out.write("\n}\n")
+        buf.write("\n}\n")
+        out.write(buf.getvalue())
 
-    print(f"\nDone: {section_count} sections, {total_entries:,} total entries -> {output_path}")
+    finally:
+        out.close()
+        if proc:
+            proc.wait()
+
+    elapsed = time.time() - start_time
+    print(f"\nDone: {section_count} sections, {total_entries:,} total entries in {elapsed:.1f}s -> {output_path}")
 
 
 def main():
@@ -125,15 +225,19 @@ def main():
         print(__doc__)
         sys.exit(1)
 
-    input_dir = sys.argv[1]
+    source = sys.argv[1]
     output_path = sys.argv[2]
 
-    if not Path(input_dir).is_dir():
-        print(f"Error: {input_dir} is not a directory")
+    if not source.startswith("gs://") and not Path(source).is_dir():
+        print(f"Error: {source} is not a directory or GCS path")
         sys.exit(1)
 
-    print(f"Assembling GKS dictionaries from {input_dir}")
-    assemble(input_dir, output_path)
+    print(f"Assembling GKS dictionaries from {source}")
+    if "orjson" in sys.modules:
+        print("  Using orjson for fast JSON processing")
+    else:
+        print("  Using stdlib json (pip install orjson for 10-50x speedup)")
+    assemble(source, output_path)
 
 
 if __name__ == "__main__":

--- a/src/scripts/assemble-gks-dicts.py
+++ b/src/scripts/assemble-gks-dicts.py
@@ -73,19 +73,20 @@ WRITE_BUFFER_SIZE = 8 * 1024 * 1024  # 8MB write buffer
 
 
 def list_gcs_files(gcs_prefix):
-    """List files in a GCS prefix using gcloud storage."""
+    """List files in a GCS prefix."""
     result = subprocess.run(
-        ["gcloud", "storage", "ls", gcs_prefix],
+        ["gsutil", "ls", gcs_prefix],
         capture_output=True, text=True, check=True,
     )
     return [line.strip() for line in result.stdout.strip().split("\n") if line.strip()]
 
 
 def open_gcs_file(gcs_path):
-    """Stream a GCS file through gcloud storage cat, decompressing if gzipped."""
+    """Stream a GCS file through gsutil cat, decompressing if gzipped."""
+    # Use gsutil cat -h which auto-decompresses gzipped content
     proc = subprocess.Popen(
-        ["gcloud", "storage", "cat", gcs_path],
-        stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        ["gsutil", "cat", gcs_path],
+        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
     )
     if gcs_path.endswith(".gz"):
         return io.TextIOWrapper(gzip.open(proc.stdout, "rb"), encoding="utf-8")
@@ -145,10 +146,10 @@ def stream_dict(filepath, opener_fn, key_field="key", value_field="value"):
 def open_output(output_path):
     """Open output file — supports local or GCS paths."""
     if output_path.startswith("gs://"):
-        # Pipe through gcloud storage cp
+        # Pipe through gsutil cp
         proc = subprocess.Popen(
-            ["gcloud", "storage", "cp", "-", output_path],
-            stdin=subprocess.PIPE, stderr=subprocess.PIPE,
+            ["gsutil", "cp", "-", output_path],
+            stdin=subprocess.PIPE, stderr=subprocess.DEVNULL,
         )
         if output_path.endswith(".gz"):
             return gzip.open(proc.stdin, "wt", encoding="utf-8"), proc

--- a/src/scripts/assemble-gks-dicts.py
+++ b/src/scripts/assemble-gks-dicts.py
@@ -61,9 +61,7 @@ SECTIONS = [
     ("condition", "condition-*.ndjson.gz", "id", None),
     ("conditionSet", "conditionSet-*.ndjson.gz", "id", None),
     ("submitter", "submitter-*.ndjson.gz", "key", "value"),
-    ("proposition", "proposition-*.ndjson.gz", "key", "value"),
-    ("vcv_proposition", "vcv_proposition-*.ndjson.gz", "key", "value"),
-    ("rcv_proposition", "rcv_proposition-*.ndjson.gz", "key", "value"),
+    ("proposition", ["proposition-*.ndjson.gz", "vcv_proposition-*.ndjson.gz", "rcv_proposition-*.ndjson.gz"], "key", "value"),
     ("scv", "scv-*.ndjson.gz", "id", None),
     ("vcv", "vcv-*.ndjson.gz", "id", None),
     ("rcv", "rcv-*.ndjson.gz", "id", None),
@@ -106,25 +104,30 @@ def open_local_file(path):
     return open(path, "r", encoding="utf-8")
 
 
-def resolve_files(source, glob_pattern):
+def resolve_files(source, glob_patterns):
     """
-    Resolve files matching a glob pattern from local dir or GCS prefix.
-    Returns list of (path_or_uri, opener_fn) tuples.
+    Resolve files matching glob pattern(s) from local dir or GCS prefix.
+    glob_patterns can be a string or list of strings.
+    Returns list of paths/URIs and an opener function.
     """
+    if isinstance(glob_patterns, str):
+        glob_patterns = [glob_patterns]
+
     if source.startswith("gs://"):
         prefix = source.rstrip("/") + "/"
         all_files = list_gcs_files(prefix)
-        # Match the glob pattern against the filename portion
         matched = []
         for uri in all_files:
             filename = uri.split("/")[-1]
-            if fnmatch(filename, glob_pattern):
+            if any(fnmatch(filename, p) for p in glob_patterns):
                 matched.append(uri)
         return sorted(matched), open_gcs_file
     else:
         local_dir = Path(source)
-        files = sorted(local_dir.glob(glob_pattern))
-        return [str(f) for f in files], open_local_file
+        matched = []
+        for pattern in glob_patterns:
+            matched.extend(local_dir.glob(pattern))
+        return sorted(set(str(f) for f in matched)), open_local_file
 
 
 def stream_dict(filepath, opener_fn, key_field="key", value_field="value"):

--- a/src/scripts/assemble-gks-dicts.py
+++ b/src/scripts/assemble-gks-dicts.py
@@ -82,20 +82,26 @@ def list_gcs_files(gcs_prefix):
 
 
 def open_gcs_file(gcs_path):
-    """Stream a GCS file through gsutil cat, decompressing if gzipped."""
-    # Use gsutil cat -h which auto-decompresses gzipped content
-    proc = subprocess.Popen(
-        ["gsutil", "cat", gcs_path],
-        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
-    )
+    """Stream a GCS file via gcloud storage cat with auto-decompression."""
+    # --raw avoids transcoding; pipe through zcat if gzipped
     if gcs_path.endswith(".gz"):
-        return io.TextIOWrapper(gzip.open(proc.stdout, "rb"), encoding="utf-8")
+        proc = subprocess.Popen(
+            f'gcloud storage cat "{gcs_path}" | zcat',
+            shell=True, stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        )
+    else:
+        proc = subprocess.Popen(
+            ["gcloud", "storage", "cat", gcs_path],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL,
+        )
     return io.TextIOWrapper(proc.stdout, encoding="utf-8")
 
 
 def open_local_file(path):
-    """Open a local file, handling gzip transparently."""
-    if str(path).endswith(".gz"):
+    """Open a local file, auto-detecting gzip by magic bytes."""
+    with open(path, "rb") as f:
+        magic = f.read(2)
+    if magic == b'\x1f\x8b':
         return gzip.open(path, "rt", encoding="utf-8")
     return open(path, "r", encoding="utf-8")
 

--- a/src/scripts/assemble-gks-dicts.py
+++ b/src/scripts/assemble-gks-dicts.py
@@ -18,22 +18,23 @@ from pathlib import Path
 
 
 # Dictionary sections in output order.
-# Each tuple is (section_name, filename, key_field, value_field).
+# Each tuple is (section_name, glob_pattern, key_field, value_field).
+# Glob patterns match sharded exports (e.g., allele-*.ndjson.gz).
 SECTIONS = [
-    ("sequenceReference", "sequenceReference.ndjson.gz", "key", "value"),
-    ("location", "location.ndjson.gz", "key", "value"),
-    ("allele", "allele.ndjson.gz", "key", "value"),
-    ("gene", "gene.ndjson.gz", "key", "value"),
-    ("variation", "variation.ndjson.gz", "key", "value"),
-    ("condition", "condition.ndjson.gz", "id", None),
-    ("conditionSet", "conditionSet.ndjson.gz", "id", None),
-    ("submitter", "submitter.ndjson.gz", "key", "value"),
-    ("proposition", "proposition.ndjson.gz", "key", "value"),
-    ("vcv_proposition", "vcv_proposition.ndjson.gz", "key", "value"),
-    ("rcv_proposition", "rcv_proposition.ndjson.gz", "key", "value"),
-    ("scv", "scv.ndjson.gz", "id", None),
-    ("vcv", "vcv.ndjson.gz", "id", None),
-    ("rcv", "rcv.ndjson.gz", "id", None),
+    ("sequenceReference", "sequenceReference-*.ndjson.gz", "key", "value"),
+    ("location", "location-*.ndjson.gz", "key", "value"),
+    ("allele", "allele-*.ndjson.gz", "key", "value"),
+    ("gene", "gene-*.ndjson.gz", "key", "value"),
+    ("variation", "variation-*.ndjson.gz", "key", "value"),
+    ("condition", "condition-*.ndjson.gz", "id", None),
+    ("conditionSet", "conditionSet-*.ndjson.gz", "id", None),
+    ("submitter", "submitter-*.ndjson.gz", "key", "value"),
+    ("proposition", "proposition-*.ndjson.gz", "key", "value"),
+    ("vcv_proposition", "vcv_proposition-*.ndjson.gz", "key", "value"),
+    ("rcv_proposition", "rcv_proposition-*.ndjson.gz", "key", "value"),
+    ("scv", "scv-*.ndjson.gz", "id", None),
+    ("vcv", "vcv-*.ndjson.gz", "id", None),
+    ("rcv", "rcv-*.ndjson.gz", "id", None),
 ]
 
 
@@ -86,27 +87,28 @@ def assemble(input_dir, output_path):
         out.write("{\n")
 
         first_section = True
-        for section_name, filename, key_field, value_field in SECTIONS:
-            filepath = input_dir / filename
-            if not filepath.exists():
-                print(f"  Skipping {section_name} ({filename} not found)")
+        for section_name, glob_pattern, key_field, value_field in SECTIONS:
+            files = sorted(input_dir.glob(glob_pattern))
+            if not files:
+                print(f"  Skipping {section_name} (no files matching {glob_pattern})")
                 continue
 
             if not first_section:
                 out.write(",\n")
             first_section = False
 
-            print(f"  Assembling {section_name} from {filename}...")
+            print(f"  Assembling {section_name} from {len(files)} file(s)...")
             out.write(f'  "{section_name}": {{\n')
 
             entry_count = 0
             first_entry = True
-            for key, value in stream_dict(filepath, key_field, value_field):
-                if not first_entry:
-                    out.write(",\n")
-                first_entry = False
-                out.write(f"    {json.dumps(key)}: {json.dumps(value, separators=(',', ':'))}")
-                entry_count += 1
+            for filepath in files:
+                for key, value in stream_dict(filepath, key_field, value_field):
+                    if not first_entry:
+                        out.write(",\n")
+                    first_entry = False
+                    out.write(f"    {json.dumps(key)}: {json.dumps(value, separators=(',', ':'))}")
+                    entry_count += 1
 
             out.write("\n  }")
             section_count += 1

--- a/src/scripts/assemble-gks-dicts.py
+++ b/src/scripts/assemble-gks-dicts.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python3
+"""
+Assemble GKS dictionary NDJSON files into a single keyed JSON file.
+
+Each input file contains rows of {"key": "...", "value": {...}} which are
+assembled into a root-level keyed dictionary per section.
+
+Usage:
+  python3 assemble-gks-dicts.py <input_dir> <output_file>
+
+Example:
+  python3 assemble-gks-dicts.py ./gks-dicts/ ./clinvar-gks-2025-06-08.json.gz
+"""
+import gzip
+import json
+import sys
+from pathlib import Path
+
+
+# Dictionary sections in output order.
+# Each tuple is (section_name, filename, key_field, value_field).
+SECTIONS = [
+    ("sequenceReference", "sequenceReference.ndjson.gz", "key", "value"),
+    ("location", "location.ndjson.gz", "key", "value"),
+    ("allele", "allele.ndjson.gz", "key", "value"),
+    ("gene", "gene.ndjson.gz", "key", "value"),
+    ("variation", "variation.ndjson.gz", "key", "value"),
+    ("condition", "condition.ndjson.gz", "id", None),
+    ("conditionSet", "conditionSet.ndjson.gz", "id", None),
+    ("submitter", "submitter.ndjson.gz", "key", "value"),
+    ("proposition", "proposition.ndjson.gz", "key", "value"),
+    ("vcv_proposition", "vcv_proposition.ndjson.gz", "key", "value"),
+    ("rcv_proposition", "rcv_proposition.ndjson.gz", "key", "value"),
+    ("scv", "scv.ndjson.gz", "id", None),
+    ("vcv", "vcv.ndjson.gz", "id", None),
+    ("rcv", "rcv.ndjson.gz", "id", None),
+]
+
+
+def open_file(path):
+    """Open a file, handling gzip transparently."""
+    if str(path).endswith(".gz"):
+        return gzip.open(path, "rt", encoding="utf-8")
+    return open(path, "r", encoding="utf-8")
+
+
+def stream_dict(ndjson_path, key_field="key", value_field="value"):
+    """
+    Yield (key, value_json_string) pairs from an NDJSON file.
+
+    If value_field is None, the entire record (minus the key field) is the value.
+    If value_field is specified and its content is a JSON string, it is parsed.
+    """
+    with open_file(ndjson_path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            key = rec[key_field]
+
+            if value_field is None:
+                # Use the whole record as the value
+                value = rec
+            else:
+                raw = rec[value_field]
+                # If the value is a JSON string, parse it
+                if isinstance(raw, str):
+                    value = json.loads(raw)
+                else:
+                    value = raw
+
+            yield key, value
+
+
+def assemble(input_dir, output_path):
+    """Assemble all dictionary NDJSON files into a single keyed JSON file."""
+    input_dir = Path(input_dir)
+    is_gzip = str(output_path).endswith(".gz")
+    opener = gzip.open if is_gzip else open
+
+    section_count = 0
+    total_entries = 0
+
+    with opener(output_path, "wt", encoding="utf-8") as out:
+        out.write("{\n")
+
+        first_section = True
+        for section_name, filename, key_field, value_field in SECTIONS:
+            filepath = input_dir / filename
+            if not filepath.exists():
+                print(f"  Skipping {section_name} ({filename} not found)")
+                continue
+
+            if not first_section:
+                out.write(",\n")
+            first_section = False
+
+            print(f"  Assembling {section_name} from {filename}...")
+            out.write(f'  "{section_name}": {{\n')
+
+            entry_count = 0
+            first_entry = True
+            for key, value in stream_dict(filepath, key_field, value_field):
+                if not first_entry:
+                    out.write(",\n")
+                first_entry = False
+                out.write(f"    {json.dumps(key)}: {json.dumps(value, separators=(',', ':'))}")
+                entry_count += 1
+
+            out.write("\n  }")
+            section_count += 1
+            total_entries += entry_count
+            print(f"    -> {entry_count:,} entries")
+
+        out.write("\n}\n")
+
+    print(f"\nDone: {section_count} sections, {total_entries:,} total entries -> {output_path}")
+
+
+def main():
+    if len(sys.argv) != 3:
+        print(__doc__)
+        sys.exit(1)
+
+    input_dir = sys.argv[1]
+    output_path = sys.argv[2]
+
+    if not Path(input_dir).is_dir():
+        print(f"Error: {input_dir} is not a directory")
+        sys.exit(1)
+
+    print(f"Assembling GKS dictionaries from {input_dir}")
+    assemble(input_dir, output_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/scripts/export-gks-dicts.sh
+++ b/src/scripts/export-gks-dicts.sh
@@ -21,7 +21,7 @@ extract() {
   # e.g., allele.ndjson.gz -> allele-*.ndjson.gz
   local sharded="${basename%.ndjson.gz}-*.ndjson.gz"
   echo "  Exporting ${table} -> ${sharded}"
-  bq extract --destination_format NEWLINE_DELIMITED_JSON \
+  bq extract --destination_format NEWLINE_DELIMITED_JSON --compression GZIP \
     "${DATASET}.${table}" "${GCS_PATH}/${sharded}"
 }
 

--- a/src/scripts/export-gks-dicts.sh
+++ b/src/scripts/export-gks-dicts.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# export-gks-dicts.sh
+# Export all GKS dictionary tables to GCS as NDJSON
+#
+# Usage: ./export-gks-dicts.sh <dataset> <gcs_bucket> [prefix]
+# Example: ./export-gks-dicts.sh clinvar_2025_06_08 clingen-dev-clinvar-gks gks-dicts
+
+set -euo pipefail
+
+DATASET="${1:?Usage: $0 <dataset> <gcs_bucket> [prefix]}"
+BUCKET="${2:?Usage: $0 <dataset> <gcs_bucket> [prefix]}"
+PREFIX="${3:-gks-dicts}"
+GCS_PATH="gs://${BUCKET}/${PREFIX}"
+
+echo "Exporting GKS dictionaries from ${DATASET} to ${GCS_PATH}"
+
+extract() {
+  local table="$1"
+  local filename="$2"
+  echo "  Exporting ${table} -> ${filename}"
+  bq extract --destination_format NEWLINE_DELIMITED_JSON \
+    "${DATASET}.${table}" "${GCS_PATH}/${filename}"
+}
+
+# Cat-VRS dictionaries (from gks_catvar_proc)
+extract gks_dict_sequence_reference sequenceReference.ndjson.gz
+extract gks_dict_location location.ndjson.gz
+extract gks_dict_allele allele.ndjson.gz
+extract gks_dict_gene gene.ndjson.gz
+extract gks_dict_variation variation.ndjson.gz
+
+# Condition dictionaries (from gks_scv_condition_proc)
+extract gks_traits condition.ndjson.gz
+extract gks_trait_sets conditionSet.ndjson.gz
+
+# SCV dictionaries (from gks_scv_statement_proc)
+extract gks_dict_submitter submitter.ndjson.gz
+extract gks_dict_proposition proposition.ndjson.gz
+
+# VCV/RCV proposition dictionaries
+extract gks_dict_vcv_proposition vcv_proposition.ndjson.gz
+extract gks_dict_rcv_proposition rcv_proposition.ndjson.gz
+
+# Statement outputs
+extract gks_scv_statement_pre scv.ndjson.gz
+extract gks_vcv_statement_pre vcv.ndjson.gz
+extract gks_rcv_statement_pre rcv.ndjson.gz
+
+echo "Done. Files exported to ${GCS_PATH}/"

--- a/src/scripts/export-gks-dicts.sh
+++ b/src/scripts/export-gks-dicts.sh
@@ -16,10 +16,13 @@ echo "Exporting GKS dictionaries from ${DATASET} to ${GCS_PATH}"
 
 extract() {
   local table="$1"
-  local filename="$2"
-  echo "  Exporting ${table} -> ${filename}"
+  local basename="$2"
+  # Use wildcard sharding to handle large tables
+  # e.g., allele.ndjson.gz -> allele-*.ndjson.gz
+  local sharded="${basename%.ndjson.gz}-*.ndjson.gz"
+  echo "  Exporting ${table} -> ${sharded}"
   bq extract --destination_format NEWLINE_DELIMITED_JSON \
-    "${DATASET}.${table}" "${GCS_PATH}/${filename}"
+    "${DATASET}.${table}" "${GCS_PATH}/${sharded}"
 }
 
 # Cat-VRS dictionaries (from gks_catvar_proc)


### PR DESCRIPTION
## Summary
- Add dictionary tables for normalized output: `gks_dict_sequence_reference`, `gks_dict_location`, `gks_dict_allele`, `gks_dict_gene`, `gks_dict_variation`, `gks_dict_submitter`, `gks_dict_proposition`, `gks_dict_vcv_proposition`, `gks_dict_rcv_proposition`
- Replace inline objects with `#/` JSON pointer references throughout (variations, alleles, genes, propositions, submitters, conditions)
- Standardize MappableConcept pattern: `classification` (conceptType + name + extensions), `strength` (conceptType + name + primaryCoding), `evidenceOutcome` (conceptType + name), `strengthOfEvidenceProvided` (conceptType + name)
- Rename `classification_mappableConcept` to `classification`, `extension` to `extensions` (plural)
- Add oncogenicity and somatic tier strength values
- Remove scv_by_ref and scv_inline from json proc, add single scv output
- Add export and assembly scripts for producing single-file GKS release

## Files changed
- `gks-catvar-proc.sql` — dictionary table creation, gene refs, variation refs
- `gks-scv-statement-proc.sql` — submitter/proposition dicts, conceptType additions
- `gks-vcv-statement-proc.sql` — proposition refs, classification rename, strength/evidenceOutcome structs
- `gks-rcv-statement-proc.sql` — same as VCV
- `gks-json-proc.sql` — simplified output, removed inline/by-ref
- `export-gks-dicts.sh` — export all dict tables to GCS
- `assemble-gks-dicts.py` — stream-assemble into single keyed JSON file

## Test plan
- [ ] Run full pipeline: condition -> catvar -> scv -> vcv -> rcv -> json
- [ ] Verify dictionary tables have correct key/value structure
- [ ] Export and assemble into single release file
- [ ] Spot-check `#/` references resolve to correct dictionary entries
- [ ] Verify MappableConcept patterns (conceptType present on classification, strength, evidenceOutcome)