### PR TITLE
Revise documentation for bundle format and dictionary refactor

### DIFF
--- a/docs/data-access/download.md
+++ b/docs/data-access/download.md
@@ -1,286 +1,50 @@
 # Downloads
 
-!!! warning "Early Adopter Release"
-    ClinVar-GKS datasets are in an **early adopter** phase. Data structures and
-    output formats may change as we incorporate community feedback and align with
-    evolving GA4GH GKS specifications. Please report issues and suggestions via
-    the [GitHub issue tracker](https://github.com/clingen-data-model/clinvar-gks/issues).
-
-ClinVar-GKS datasets are hosted on Cloudflare R2 object storage. All downloads are free with no authentication required and no egress fees.
+ClinVar-GKS releases are hosted on Cloudflare R2 object storage. All downloads are free with no authentication required and no egress fees.
 
 ---
 
 ## Latest Release
 
-The `current/` directory always contains the most recent weekly release with stable filenames:
-
-| Dataset | URL |
-| --- | --- |
-| Categorical Variants | `https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/clinvar_gks_variation.jsonl.gz` |
-| SCV Statements | `https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/clinvar_gks_scv_by_ref.jsonl.gz` |
-| Release Manifest | `https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/manifest.json` |
-
-The `manifest.json` file contains metadata about the current release — release date, schema version, and the list of published files.
-
-### Download with curl
+The `current/` directory contains the most recent weekly releases with stable filenames:
 
 ```bash
-# Download latest categorical variants
-curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/clinvar_gks_variation.jsonl.gz
-
-# Download latest SCV statements
-curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/clinvar_gks_scv_by_ref.jsonl.gz
-
-# Check which release is current
-curl -s https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/manifest.json | python3 -m json.tool
+# Download the latest release
+curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/clinvar-gks-current.json.gz
 ```
 
-### Download with Python
+---
+
+## Monthly Archives
+
+Archived releases are available by year, one per month:
+
+```bash
+# Download the February 2025 archive
+curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/archive/2025/clinvar-gks_2025_02.json.gz
+```
+
+---
+
+## Download with Python
 
 ```python
-import urllib.request, json
+import urllib.request
 
 BASE = "https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev"
 
-# Check current release metadata
-with urllib.request.urlopen(f"{BASE}/current/manifest.json") as r:
-    manifest = json.loads(r.read())
-    print(f"Release: {manifest['release_date']} ({manifest['schema_version']})")
-
-# Download a dataset
+# Download current release
 urllib.request.urlretrieve(
-    f"{BASE}/current/clinvar_gks_variation.jsonl.gz",
-    "clinvar_gks_variation.jsonl.gz"
+    f"{BASE}/current/clinvar-gks-current.json.gz",
+    "clinvar-gks-current.json.gz"
 )
-```
-
----
-
-## Browse All Releases
-
-The file browser below is populated from the release index and updated automatically with each weekly upload.
-
-<div id="r2-browser" markdown>
-
-<noscript>
-
-JavaScript is required to browse releases interactively. Use the release index directly:
-
-```bash
-curl -s https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/index.json | python3 -m json.tool
-```
-
-</noscript>
-
-<p id="r2-loading" style="color: var(--md-default-fg-color--light); font-style: italic;">Loading release index...</p>
-<div id="r2-error" style="display: none; padding: 0.8rem; border-left: 3px solid var(--md-accent-fg-color); margin: 1rem 0;"></div>
-<div id="r2-tree" style="display: none;"></div>
-
-</div>
-
-<style>
-#r2-tree { font-family: var(--md-code-font-family); font-size: 0.82rem; line-height: 1.6; }
-.r2-year, .r2-month { margin: 0; padding: 0; }
-.r2-year > summary, .r2-month > summary {
-  cursor: pointer; font-weight: 600; padding: 0.15rem 0;
-  color: var(--md-default-fg-color);
-  list-style: none;
-}
-.r2-year > summary::before, .r2-month > summary::before {
-  content: "▸ "; color: var(--md-default-fg-color--light);
-}
-.r2-year[open] > summary::before, .r2-month[open] > summary::before {
-  content: "▾ ";
-}
-.r2-release { padding: 0.2rem 0 0.2rem 1.2rem; border-left: 1px solid var(--md-default-fg-color--lightest); margin-left: 0.4rem; }
-.r2-release-header { font-weight: 600; color: var(--md-default-fg-color); margin-bottom: 0.15rem; }
-.r2-file { padding-left: 1.2rem; }
-.r2-file a { text-decoration: none; color: var(--md-typeset-a-color); }
-.r2-file a:hover { text-decoration: underline; }
-.r2-badge {
-  display: inline-block; font-size: 0.7rem; padding: 0.05rem 0.35rem;
-  border-radius: 3px; margin-left: 0.4rem; vertical-align: middle;
-  background: var(--md-accent-fg-color); color: var(--md-accent-bg-color);
-}
-.r2-current { margin-bottom: 1.5rem; padding: 0.8rem; border: 1px solid var(--md-accent-fg-color); border-radius: 4px; }
-.r2-current-title { font-weight: 700; font-size: 0.95rem; margin-bottom: 0.4rem; }
-</style>
-
-<script>
-(function() {
-  var INDEX_URL = "https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/index.json";
-
-  function el(tag, attrs, children) {
-    var e = document.createElement(tag);
-    if (attrs) Object.keys(attrs).forEach(function(k) {
-      if (k === "text") e.textContent = attrs[k];
-      else if (k === "html") e.innerHTML = attrs[k];
-      else if (k === "className") e.className = attrs[k];
-      else if (k === "style") Object.assign(e.style, attrs[k]);
-      else e.setAttribute(k, attrs[k]);
-    });
-    if (children) children.forEach(function(c) { if (c) e.appendChild(c); });
-    return e;
-  }
-
-  function renderFile(baseUrl, path, filename) {
-    var url = baseUrl + "/" + path + filename;
-    var div = el("div", {className: "r2-file"});
-    div.appendChild(el("a", {href: url, text: filename}));
-    return div;
-  }
-
-  function renderRelease(baseUrl, release, isCurrent) {
-    var div = el("div", {className: "r2-release"});
-    var header = el("div", {className: "r2-release-header"});
-    header.appendChild(el("span", {text: release.date}));
-    header.appendChild(el("span", {
-      text: release.version,
-      style: {marginLeft: "0.6rem", fontWeight: "normal", color: "var(--md-default-fg-color--light)"}
-    }));
-    if (isCurrent) header.appendChild(el("span", {className: "r2-badge", text: "latest"}));
-    div.appendChild(header);
-
-    var files = release.files || [];
-    files.forEach(function(f) { div.appendChild(renderFile(baseUrl, release.path, f)); });
-    div.appendChild(renderFile(baseUrl, release.path, "manifest.json"));
-    return div;
-  }
-
-  function buildTree(data) {
-    var container = document.getElementById("r2-tree");
-    var releases = data.releases || [];
-    var baseUrl = data.base_url || "";
-
-    if (releases.length === 0) {
-      container.innerHTML = "<p>No releases found.</p>";
-      container.style.display = "block";
-      return;
-    }
-
-    // Current release highlight
-    var latest = releases[releases.length - 1];
-    var currentDiv = el("div", {className: "r2-current"});
-    currentDiv.appendChild(el("div", {className: "r2-current-title", html: "Current Release <span class='r2-badge'>latest</span>"}));
-    var stableFiles = ["clinvar_gks_variation.jsonl.gz", "clinvar_gks_scv_by_ref.jsonl.gz", "manifest.json"];
-    stableFiles.forEach(function(f) {
-      var url = baseUrl + "/current/" + f;
-      var row = el("div", {className: "r2-file"});
-      row.appendChild(el("a", {href: url, text: f}));
-      currentDiv.appendChild(row);
-    });
-    currentDiv.appendChild(el("div", {
-      style: {marginTop: "0.3rem", fontSize: "0.78rem", color: "var(--md-default-fg-color--light)"},
-      text: "Release " + latest.date + " (" + latest.version + ") \u2014 stable URLs, always the most recent data"
-    }));
-    container.appendChild(currentDiv);
-
-    // Group by year and month
-    var years = {};
-    releases.forEach(function(r) {
-      var y = r.date.substring(0, 4);
-      var m = r.date.substring(0, 7);
-      if (!years[y]) years[y] = {};
-      if (!years[y][m]) years[y][m] = [];
-      years[y][m].push(r);
-    });
-
-    // Archive heading
-    container.appendChild(el("div", {
-      style: {fontWeight: "700", fontSize: "0.95rem", marginBottom: "0.4rem"},
-      text: "Archived Releases"
-    }));
-
-    // Render years in reverse order, most recent month open
-    var sortedYears = Object.keys(years).sort().reverse();
-    var firstYear = true;
-    sortedYears.forEach(function(y) {
-      var yearDetails = el("details", {className: "r2-year"});
-      if (firstYear) yearDetails.setAttribute("open", "");
-      yearDetails.appendChild(el("summary", {text: y}));
-
-      var sortedMonths = Object.keys(years[y]).sort().reverse();
-      var firstMonth = true;
-      sortedMonths.forEach(function(m) {
-        var monthDetails = el("details", {className: "r2-month"});
-        if (firstYear && firstMonth) monthDetails.setAttribute("open", "");
-        monthDetails.appendChild(el("summary", {text: m}));
-
-        var monthReleases = years[y][m].sort(function(a, b) { return b.date.localeCompare(a.date); });
-        monthReleases.forEach(function(r) {
-          monthDetails.appendChild(renderRelease(baseUrl, r, r === latest));
-        });
-        yearDetails.appendChild(monthDetails);
-        firstMonth = false;
-      });
-      container.appendChild(yearDetails);
-      firstYear = false;
-    });
-
-    container.style.display = "block";
-  }
-
-  fetch(INDEX_URL)
-    .then(function(r) {
-      if (!r.ok) throw new Error("HTTP " + r.status);
-      return r.json();
-    })
-    .then(function(data) {
-      document.getElementById("r2-loading").style.display = "none";
-      buildTree(data);
-    })
-    .catch(function(err) {
-      document.getElementById("r2-loading").style.display = "none";
-      var errDiv = document.getElementById("r2-error");
-      errDiv.style.display = "block";
-      errDiv.textContent = "Unable to load release index. Use the curl command above to access index.json directly. (" + err.message + ")";
-    });
-})();
-</script>
-
----
-
-## Release Cadence
-
-New datasets are published weekly, typically within 1-2 days of each ClinVar XML release. The `current/` files are overwritten with each new release. Archived releases are retained indefinitely.
-
----
-
-## File Sizes
-
-Typical compressed file sizes per release:
-
-| Dataset | Approximate Size |
-| --- | --- |
-| `variation` | ~1.5 GB |
-| `scv_by_ref` | ~2.0 GB |
-
-Total download for a full weekly release is approximately 3.5 GB.
-
----
-
-## Programmatic Access
-
-The storage endpoint is S3-compatible. Tools that support custom S3 endpoints can access the bucket directly:
-
-```bash
-# Using AWS CLI (no credentials needed for public reads)
-aws s3 ls s3://clinvar-gks/current/ \
-  --endpoint-url https://09208aa33790838db213a21f630c33e7.r2.cloudflarestorage.com \
-  --no-sign-request
-```
-
-The release index can be fetched programmatically to discover all available releases:
-
-```bash
-curl -s https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/index.json | python3 -m json.tool
 ```
 
 ---
 
 ## Feedback
 
-This project is in active development and we welcome feedback from early adopters. If you encounter data quality issues, have questions about the output format, or want to suggest improvements:
+This project is in active development and we welcome community feedback. If you encounter data quality issues, have questions about the output format, or want to suggest improvements:
 
 - Open an issue on [GitHub](https://github.com/clingen-data-model/clinvar-gks/issues)
-- Include the release date (from `manifest.json`) and the dataset file involved
+- Include the release date and specific records involved

--- a/docs/data-access/index.md
+++ b/docs/data-access/index.md
@@ -18,7 +18,7 @@ Download the latest release:
 curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/clinvar-gks-current.json.gz
 ```
 
-Each release file is a single JSON object containing all dictionary sections — variations, statements, propositions, conditions, and supporting reference data. See [Output Format](../output-reference/overview.md) for the complete structure.
+Each release file is a single JSON object containing all bundle sections — variations, statements, propositions, conditions, and supporting reference data. See [Output Format](../output-reference/overview.md) for the complete structure.
 
 ---
 
@@ -61,7 +61,7 @@ Each release — weekly and monthly — is accompanied by a release notes file (
 
 ## File Format
 
-Each release is a **gzip-compressed JSON file** (`.json.gz`). The decompressed content is a single JSON object with dictionary sections at the root level:
+Each release is a **gzip-compressed JSON file** (`.json.gz`). The decompressed content is a single JSON object with bundle sections at the root level:
 
 ```json
 {
@@ -80,7 +80,7 @@ Each release is a **gzip-compressed JSON file** (`.json.gz`). The decompressed c
 }
 ```
 
-Each section is a keyed dictionary — the key is the object's unique identifier, and the value is the complete object. Objects reference each other using `#/` JSON pointer strings.
+Each section is a keyed collection — the key is the object's unique identifier, and the value is the complete object. Objects reference each other using `#/` JSON pointer strings.
 
 See [Output Format](../output-reference/overview.md) for detailed documentation of each section.
 
@@ -88,6 +88,6 @@ See [Output Format](../output-reference/overview.md) for detailed documentation 
 
 ## What's Next
 
-- [Output Format](../output-reference/overview.md) — the bundled dictionary structure and reference patterns
+- [Output Format](../output-reference/overview.md) — the bundle structure and reference patterns
 - [Examples](examples.md) — annotated sample records from each section
 - [Pipeline Overview](../pipeline/index.md) — how the data is produced from ClinVar XML

--- a/docs/data-access/index.md
+++ b/docs/data-access/index.md
@@ -1,47 +1,93 @@
 # Data Access
 
-!!! warning "Early Adopter Release"
-    ClinVar-GKS datasets are currently in an **early adopter** phase. The data
-    structures, field names, and output formats may change as we incorporate
-    feedback and align with evolving GA4GH GKS specifications. We encourage
-    early adopters to report issues and suggestions via the
-    [GitHub issue tracker](https://github.com/clingen-data-model/clinvar-gks/issues).
-
-ClinVar-GKS output datasets are published weekly as gzip-compressed JSONL files, synchronized with each ClinVar XML release. The datasets are freely available for download from Cloudflare R2 object storage with no authentication required and no egress fees.
+ClinVar-GKS releases are published weekly as a single gzip-compressed JSON file, synchronized with each ClinVar XML release. The files are freely available for download from Cloudflare R2 object storage with no authentication required and no egress fees.
 
 ---
 
-## Available Datasets
+## Current Release
 
-Each weekly release produces the following files:
+The most recent weekly releases for the current month are available at:
 
-| Dataset | Description |
-|---|---|
-| **Categorical Variants** (`variation`) | Cat-VRS categorical variant representations for all ClinVar variations |
-| **SCV Statements** (`scv_by_ref`) | VA-Spec SCV classification statements with variations referenced by VRS ID |
-
-See [Output Files](output-files.md) for detailed format documentation and field descriptions.
-
----
-
-## Quick Start
-
-Download the latest release files directly:
-
-```bash
-# Latest categorical variants
-curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/clinvar_gks_variation.jsonl.gz
-
-# Latest SCV statements (by reference)
-curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/clinvar_gks_scv_by_ref.jsonl.gz
+```text
+https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/
 ```
 
-See [Downloads](download.md) for the full URL structure, archived releases, and programmatic access patterns.
+Download the latest release:
+
+```bash
+curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/clinvar-gks-current.json.gz
+```
+
+Each release file is a single JSON object containing all dictionary sections — variations, statements, propositions, conditions, and supporting reference data. See [Output Format](../output-reference/overview.md) for the complete structure.
+
+---
+
+## Release Schedule
+
+- **Weekly releases** are published within the current month, one per ClinVar XML release
+- **Monthly archives** retain one release per prior month, based on the last release of that month
+
+All weekly releases for the current month are available at the `current/` endpoint. As a new month begins, the prior month's final release moves to the archive.
+
+---
+
+## Archives
+
+Monthly archived releases are available at:
+
+```text
+https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/archive/{year}/
+```
+
+Archive files include the year and month in the filename — for example, `clinvar-gks_2025_02.json.gz` for the February 2025 archive release.
+
+Example — download the February 2025 archive:
+
+```bash
+curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/archive/2025/clinvar-gks_2025_02.json.gz
+```
+
+---
+
+## Release Notes
+
+Each release — weekly and monthly — is accompanied by a release notes file (`.md` or `.txt`) in the same directory. Release notes include:
+
+- The ClinVar XML release date and version
+- Record counts per section (variations, SCVs, VCVs, RCVs)
+- Known issues or changes specific to the release
+
+---
+
+## File Format
+
+Each release is a **gzip-compressed JSON file** (`.json.gz`). The decompressed content is a single JSON object with dictionary sections at the root level:
+
+```json
+{
+  "sequenceReference": { ... },
+  "location": { ... },
+  "allele": { ... },
+  "gene": { ... },
+  "variation": { ... },
+  "condition": { ... },
+  "conditionSet": { ... },
+  "submitter": { ... },
+  "proposition": { ... },
+  "scv": { ... },
+  "vcv": { ... },
+  "rcv": { ... }
+}
+```
+
+Each section is a keyed dictionary — the key is the object's unique identifier, and the value is the complete object. Objects reference each other using `#/` JSON pointer strings.
+
+See [Output Format](../output-reference/overview.md) for detailed documentation of each section.
 
 ---
 
 ## What's Next
 
-- Browse [Examples](examples.md) for annotated sample records from each dataset
-- Review the [Output Reference](../output-reference/index.md) for complete field documentation
-- Check the [Profiles](../profiles/index.md) section for classification types, propositions, and review status mappings
+- [Output Format](../output-reference/overview.md) — the bundled dictionary structure and reference patterns
+- [Examples](examples.md) — annotated sample records from each section
+- [Pipeline Overview](../pipeline/index.md) — how the data is produced from ClinVar XML

--- a/docs/data-access/output-files.md
+++ b/docs/data-access/output-files.md
@@ -1,98 +1,114 @@
-# Output Files
+# Output File
 
-!!! warning "Early Adopter Release"
-    Output file contents and structure may change as the project incorporates
-    feedback and aligns with evolving GA4GH GKS specifications.
-
-The ClinVar-GKS pipeline produces gzip-compressed JSONL files — one JSON object per line, each representing a single record. Files are published weekly in sync with ClinVar XML releases.
+Each ClinVar-GKS release is published as a **single gzip-compressed JSON file** containing all data for the corresponding ClinVar XML release in the bundle format.
 
 ---
 
-## File Summary
+## File Format
 
-| File | Record Type | GA4GH Spec | Typical Size |
-| --- | --- | --- | --- |
-| `clinvar_gks_variation.jsonl.gz` | `CategoricalVariant` | Cat-VRS | ~1.5 GB |
-| `clinvar_gks_scv_by_ref.jsonl.gz` | `Statement` | VA-Spec | ~2.0 GB |
-
----
-
-## Categorical Variants (`variation`)
-
-Each line is a Cat-VRS `CategoricalVariant` object representing a single ClinVar variation. The record includes VRS-normalized identifiers, genomic expressions (HGVS, SPDI, gnomAD), cross-references, gene associations, and assembly mappings.
-
-**Record count:** ~2.8 million per release (one per ClinVar variation)
-
-**Key fields:**
-
-- `id` — VRS-computed categorical variant identifier
-- `type` — Cat-VRS type (e.g., `CanonicalAllele`)
-- `members` — VRS allele definitions with sequence locations
-- `mappings` — cross-references to external databases (ClinVar, ClinGen, OMIM)
-- `extensions` — HGVS expressions, gene context, molecular consequences
-
-See [Categorical Variants output reference](../output-reference/cat-vrs.md) for full field documentation and [Cat-VRS examples](examples.md#categorical-variants-cat-vrs) for annotated samples.
-
----
-
-## SCV Statements (`scv_by_ref`)
-
-Each line is a VA-Spec `Statement` object representing a single ClinVar submitted classification (SCV). Variations are referenced by their VRS ID rather than embedded inline, keeping file size manageable.
-
-**Record count:** ~4.1 million per release (one per ClinVar SCV)
-
-**Key fields:**
-
-- `id` — statement identifier derived from the SCV accession
-- `type` — VA-Spec statement type (e.g., `Statement`)
-- `classification` — the submitted clinical classification
-- `proposition` — the clinical assertion (variant, condition, predicate)
-- `strength` — review status and assertion criteria
-- `direction` — whether the evidence supports or disputes the proposition
-- `extensions` — submission metadata, submitter details, review status
-
-See [SCV Statements output reference](../output-reference/scv-statements.md) for full field documentation and [SCV examples](examples.md#scv-statements) for annotated samples.
-
----
-
-## File Format Details
-
-### JSONL Structure
-
-Files use newline-delimited JSON (JSONL) format — each line is a complete, self-contained JSON object. No wrapper array or document-level metadata.
+The release file is a `.json.gz` file. The decompressed content is a single JSON object with named bundle sections at the root level — each section is a keyed collection of objects of the same class.
 
 ```bash
-# Inspect the first record
-gunzip -c clinvar_gks_variation.jsonl.gz | head -1 | python3 -m json.tool
+# Decompress and inspect the top-level keys
+gunzip -c clinvar-gks-current.json.gz | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for key in data:
+    print(f'{key}: {len(data[key]):,} entries')
+"
 ```
 
-### Compression
+See [Output Format](../output-reference/overview.md) for the full bundle structure, section inventory, and reference patterns.
 
-All files are gzip-compressed. Standard tools handle decompression transparently:
+---
 
-```bash
-# Stream without decompressing to disk
-gunzip -c clinvar_gks_scv_by_ref.jsonl.gz | wc -l
+## File Naming Convention
 
-# Python
-import gzip, json
-with gzip.open('clinvar_gks_variation.jsonl.gz', 'rt') as f:
-    for line in f:
-        record = json.loads(line)
-```
+### Current Release
 
-### File Naming Convention
-
-Published files follow this naming pattern:
+The `current/` endpoint uses a stable filename:
 
 ```text
-clinvar_gks_{dataset}_{YYYY_MM_DD}_{version}.jsonl.gz
+clinvar-gks-current.json.gz
 ```
 
-| Component | Description | Example |
-| --- | --- | --- |
-| `dataset` | Output type identifier | `variation`, `scv_by_ref` |
-| `YYYY_MM_DD` | ClinVar release date | `2026_03_15` |
-| `version` | Dataset schema version | `v2_4_3` |
+### Weekly Releases
 
-The `current/` directory uses stable filenames without the date or version suffix — see [Downloads](download.md) for details.
+Weekly releases within the current month include the release date:
+
+```text
+clinvar-gks-{YYYY-MM-DD}.json.gz
+```
+
+### Monthly Archives
+
+Archived monthly releases include the year and month:
+
+```text
+clinvar-gks_{YYYY}_{MM}.json.gz
+```
+
+---
+
+## Working with the File
+
+### Python
+
+```python
+import gzip
+import json
+
+with gzip.open('clinvar-gks-current.json.gz', 'rt') as f:
+    bundle = json.load(f)
+
+# Look up a specific variation
+variant = bundle['variation']['clinvar:10']
+print(variant['name'])
+
+# Resolve a reference
+allele_ref = variant['members'][0]  # e.g., "#/allele/ga4gh:VA.abc123"
+section, key = allele_ref.lstrip('#/').split('/', 1)
+allele = bundle[section][key]
+```
+
+### Command Line
+
+```bash
+# Count entries per section
+gunzip -c clinvar-gks-current.json.gz | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for key in data:
+    print(f'{key}: {len(data[key]):,}')
+"
+
+# Extract a single variation as pretty-printed JSON
+gunzip -c clinvar-gks-current.json.gz | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+print(json.dumps(data['variation']['clinvar:10'], indent=2))
+"
+```
+
+---
+
+## Sections Included
+
+Each release file contains the following bundle sections:
+
+| Section | Content |
+| --- | --- |
+| `sequenceReference` | VRS reference sequences with refget accessions |
+| `location` | VRS sequence locations with coordinates |
+| `allele` | VRS alleles with state and expressions |
+| `gene` | Gene records with identifiers and symbols |
+| `variation` | Cat-VRS categorical variants |
+| `condition` | Trait and disease concepts |
+| `conditionSet` | Multi-condition groupings |
+| `submitter` | Submitting organizations |
+| `proposition` | Classification propositions (SCV, VCV, and RCV) |
+| `scv` | Submitted classification statements |
+| `vcv` | Variation-level aggregate statements |
+| `rcv` | Condition-level aggregate statements |
+
+See [Data Model](../output-reference/classes/index.md) for class descriptions and relationship diagrams.

--- a/docs/drafts/acmgv4-variant-pathogenicity/index.md
+++ b/docs/drafts/acmgv4-variant-pathogenicity/index.md
@@ -235,4 +235,4 @@ These need formalization as part of the VA-Spec terminological standards.
 - [Statement Types](../../profiles/statement-types.md) — ClinVar-GKS statement type mappings
 - [Classifications](../../profiles/classifications.md) — classification values with direction/strength
 - [Propositions](../../profiles/propositions.md) — proposition type mappings
-- [VA-Spec](https://va-spec.readthedocs.io/) — GA4GH Variant Annotation Specification
+- [VA-Spec](https://va-spec.ga4gh.org/) — GA4GH Variant Annotation Specification

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,61 +1,97 @@
 # Getting Started
 
-## Accessing the Datasets
+## Download the Latest Release
 
-ClinVar-GKS output files are published to a public Google Cloud Storage bucket after each pipeline run.
-
-### Public Bucket
+The current ClinVar-GKS release is available as a single compressed JSON file:
 
 ```
-gs://clingen-public/clinvar-gks/
+https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/
 ```
 
-### File Naming Convention
-
-Files follow this naming pattern:
-
-```
-clinvar_gks_{type}_{YYYY_MM_DD}_{version}.jsonl.gz
-```
-
-Where:
-
-- `{type}` is one of: `variation`, `scv_by_ref`, `scv_inline`
-- `{YYYY_MM_DD}` is the ClinVar release date
-- `{version}` is the dataset version (e.g., `v2_4_3`)
-
-### Download Examples
-
-Using `gsutil`:
+Download and decompress:
 
 ```bash
-# List available files
-gsutil ls gs://clingen-public/clinvar-gks/
+# Download the latest release
+curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/clinvar-gks-current.json.gz
 
-# Download the latest variation file
-gsutil cp gs://clingen-public/clinvar-gks/clinvar_gks_variation_2025_09_28_v2_4_3.jsonl.gz .
-
-# Download and decompress
-gsutil cat gs://clingen-public/clinvar-gks/clinvar_gks_variation_2025_09_28_v2_4_3.jsonl.gz | gunzip > variation.jsonl
+# Decompress
+gunzip clinvar-gks-current.json.gz
 ```
 
-### File Format
+See [Data Access](data-access/index.md) for the full release schedule, archives, and file naming conventions.
 
-All files are **gzipped newline-delimited JSON** (`.jsonl.gz`). Each line is a self-contained JSON object conforming to the relevant GA4GH schema.
+---
 
-## What's In Each File
+## What's in the File
 
-| File | Contents | Schema |
-| --- | --- | --- |
-| `variation` | Cat-VRS categorical variant objects for all ClinVar variations | Cat-VRS 1.0 |
-| `scv_by_ref` | VA-Spec clinical statements referencing variations by ID | VA-Spec 1.0 |
-| `scv_inline` | VA-Spec clinical statements with full variation objects embedded | VA-Spec 1.0 |
+The release file is a single JSON object with **dictionary sections** at the root level. Each section is a keyed collection of objects — the key is the object's unique identifier, and the value is the object itself.
 
-The `scv_by_ref` and `scv_inline` files contain the same statements — they differ only in whether the variant is referenced or inlined. Use `scv_by_ref` if you already have the variation data loaded; use `scv_inline` for self-contained records.
+```json
+{
+  "sequenceReference": { "SQ.abc123": { ... } },
+  "location":          { "ga4gh:SL.xyz789": { ... } },
+  "allele":            { "ga4gh:VA.def456": { ... } },
+  "gene":              { "ncbigene:3077": { ... } },
+  "variation":         { "clinvar:10": { ... } },
+  "condition":         { "clinvar.trait:9580": { ... } },
+  "conditionSet":      { "clinvar.traitset:1234": { ... } },
+  "submitter":         { "clinvar.submitter:500139": { ... } },
+  "proposition":       { "SCV001234567-PATH": { ... } },
+  "scv":               { "clinvar.submission:SCV001234567.1": { ... } },
+  "vcv":               { "VCV000012582.63-G-PATH-CP": { ... } },
+  "rcv":               { "RCV000012345.8-G-PATH-CP": { ... } }
+}
+```
+
+Objects reference each other using `#/` JSON pointer strings. For example, an allele references its location as `"#/location/ga4gh:SL.xyz789"`, and an SCV statement references its proposition as `"#/proposition/SCV001234567-PATH"`.
+
+See [Output Format](output-reference/overview.md) for the full structure and reference patterns.
+
+---
+
+## Quick Example
+
+To find the classification statements for a specific variant, start with the variation ID. ClinVar variation 10 (the HFE p.His63Asp variant) has the key `clinvar:10` in the `variation` section:
+
+```json
+{
+  "variation": {
+    "clinvar:10": {
+      "id": "clinvar:10",
+      "type": "CategoricalVariant",
+      "name": "NM_000410.4(HFE):c.187C>G (p.His63Asp)",
+      "members": ["#/allele/ga4gh:VA.ELQCnIBGqaTl0AEE0Az18XZ2cgIHAQIY"],
+      "constraints": [ ... ],
+      "extensions": [ ... ],
+      "mappings": [ ... ]
+    }
+  }
+}
+```
+
+The SCV statements for this variant reference it via `#/variation/clinvar:10` in their propositions. To find them, look for entries in the `proposition` section where `subjectVariant` matches, then find the corresponding `scv` entries that reference those propositions.
+
+---
+
+## Key Concepts
+
+**Statements** are the core unit of ClinVar-GKS. Each statement represents a clinical classification — either submitted (SCV), aggregated per variation (VCV), or aggregated per condition (RCV). Statements carry:
+
+- A **classification** — the clinical significance label (e.g., Pathogenic, Likely benign)
+- A **proposition** — what the classification asserts (variant X causes condition Y)
+- **Direction** and **strength** — whether the evidence supports, disputes, or is neutral toward the proposition
+- **Evidence lines** — links to the contributing submissions or lower-level aggregations
+- **Extensions** — provenance metadata including submitted conditions, review status, and submission details
+
+**Propositions** define the relationship being classified — a variant's causal role for a condition, its oncogenic potential, or its clinical impact. Each proposition has a type (e.g., `VariantPathogenicityProposition`), a predicate (e.g., `isCausalFor`), a subject variant, and an object condition.
+
+**Conditions** represent the diseases or phenotypes that classifications are made against. Single conditions reference `#/condition/clinvar.trait:{id}`, while multi-condition sets reference `#/conditionSet/clinvar.traitSet:{id}`.
+
+---
 
 ## Next Steps
 
-- [Pipeline Overview](pipeline/index.md) — understand how the data is produced
-- [Statement Profiles](profiles/index.md) — learn about the 14 statement types and their classifications
-- [Output File Schemas](data-access/output-files.md) — detailed field documentation
+- [Output Format](output-reference/overview.md) — detailed guide to the bundled dictionary structure
+- [Pipeline Overview](pipeline/index.md) — how the data is produced from ClinVar XML
+- [Statement Profiles](profiles/index.md) — the 14 statement types and their classifications
 - [Examples](data-access/examples.md) — annotated JSON examples

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -4,7 +4,7 @@
 
 The current ClinVar-GKS release is available as a single compressed JSON file:
 
-```
+```text
 https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/
 ```
 
@@ -24,7 +24,7 @@ See [Data Access](data-access/index.md) for the full release schedule, archives,
 
 ## What's in the File
 
-The release file is a single JSON object with **dictionary sections** at the root level. Each section is a keyed collection of objects — the key is the object's unique identifier, and the value is the object itself.
+The release file is a single JSON object with **bundle sections** at the root level. Each section is a keyed collection of objects — the key is the object's unique identifier, and the value is the object itself.
 
 ```json
 {
@@ -91,7 +91,7 @@ The SCV statements for this variant reference it via `#/variation/clinvar:10` in
 
 ## Next Steps
 
-- [Output Format](output-reference/overview.md) — detailed guide to the bundled dictionary structure
+- [Output Format](output-reference/overview.md) — detailed guide to the bundle format
 - [Pipeline Overview](pipeline/index.md) — how the data is produced from ClinVar XML
 - [Statement Profiles](profiles/index.md) — the 14 statement types and their classifications
 - [Examples](data-access/examples.md) — annotated JSON examples

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,38 +1,49 @@
 # ClinVar-GKS
 
-ClinVar-GKS is a data transformation pipeline that converts [ClinVar](https://www.ncbi.nlm.nih.gov/clinvar/) release data into its [GA4GH GKS](https://www.ga4gh.org/genomic-knowledge-standards/) (Genomic Knowledge Standards) equivalent. It is developed and maintained by the [ClinGen](https://clinicalgenome.org/) driver project.
+ClinVar-GKS provides a standardized, machine-readable representation of [ClinVar](https://www.ncbi.nlm.nih.gov/clinvar/) release data using the [GA4GH Genomic Knowledge Standards](https://www.ga4gh.org/genomic-knowledge-standards/) (GKS). It is developed and maintained by the [ClinGen](https://clinicalgenome.org/) driver project.
 
-## What It Does
+## Why ClinVar-GKS
 
-The pipeline processes the **entirety** of each ClinVar XML release — every variation, submitted classification, and aggregate record — and transforms them into standardized GA4GH formats:
+ClinVar is one of the most widely used public archives of human genetic variation and its relationship to disease. However, the native ClinVar XML format presents challenges for programmatic consumption — inconsistent structures, deeply nested records, and representations that do not align with emerging genomic data standards.
 
-- **[VRS](https://vrs.ga4gh.org/)** (Variation Representation Specification) — normalized, computable variant identifiers
-- **[Cat-VRS](https://cat-vrs.readthedocs.io/)** (Categorical VRS) — categorical variant representations (canonical alleles, copy number variants)
-- **[VA-Spec](https://va-spec.readthedocs.io/)** (Variant Annotation Specification) — variant classification statements
+ClinVar-GKS addresses these challenges by transforming every ClinVar release into a consistent, semantically rich format built on GA4GH specifications:
+
+- **Normalized variant identifiers** — Every variant receives a computable [VRS](https://vrs.ga4gh.org/) identifier, enabling unambiguous cross-system matching
+- **Categorical variant representations** — Variants are represented as [Cat-VRS](https://cat-vrs.readthedocs.io/) categorical variants with defining allele constraints and expressions
+- **Structured classification statements** — Every submitted (SCV), aggregate (VCV), and condition-level (RCV) classification is represented as a [VA-Spec](https://va-spec.readthedocs.io/) statement with explicit propositions, evidence, and provenance
+- **Semantic consistency** — Classifications, propositions, conditions, genes, and cross-references use standardized structures with typed references
+
+## What It Covers
+
+The pipeline processes the **entirety** of each ClinVar XML release:
+
+- **~2.8 million** variations with VRS-normalized alleles and locations
+- **~4.1 million** submitted clinical classifications (SCVs) across germline, somatic, and oncogenicity statement types
+- **~870,000** aggregate variation classifications (VCVs) with multi-layer aggregation
+- **~1.1 million** condition-level aggregate classifications (RCVs)
+
+New releases are produced weekly, synchronized with ClinVar's release schedule.
 
 ## Who It's For
 
-- **Implementers** building tools that consume ClinVar data in GA4GH standard format
-- **Researchers** who need programmatic access to normalized ClinVar classifications
-- **GA4GH specification developers** using ClinVar-GKS as a real-world validation of GKS schemas
+- **Variant scientists** seeking a clear, consistent representation of ClinVar classifications with explicit propositions, conditions, and evidence
+- **Platform engineers** building systems that consume ClinVar data and need a structured, well-documented format for integration
+- **GA4GH implementers** using ClinVar-GKS as a real-world validation of VRS, Cat-VRS, and VA-Spec schemas
+
+## How to Get the Data
+
+The latest release is available as a single compressed JSON file:
+
+**Current release:** [`https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/`](https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/)
+
+See [Data Access](data-access/index.md) for the full release schedule, archive policy, and file format details.
 
 ## How It Works
 
-The pipeline runs on **Google BigQuery** using SQL stored procedures, with an external VRS Python processing step. It is designed for periodic batch processing, typically running weekly in sync with ClinVar releases.
+The pipeline runs on **Google BigQuery** using SQL stored procedures, with an external VRS Python processing step. Each release is fully reprocessed from the source ClinVar XML — there is no incremental state between releases.
 
-See the [Pipeline Overview](pipeline/index.md) for the full workflow, or jump to [Getting Started](getting-started.md) to access the output datasets.
-
-## Output Datasets
-
-Each pipeline run produces gzip-compressed JSONL files distributed via Cloudflare R2:
-
-| File | Description |
-| --- | --- |
-| `variation` | Cat-VRS categorical variant representations for all ClinVar variations |
-| `scv_by_ref` | VA-Spec SCV statements with variations referenced by ID |
-
-See [Data Access](data-access/index.md) for download URLs and format details.
+See the [Pipeline Overview](pipeline/index.md) for the full workflow, or jump to [Getting Started](getting-started.md) for a quick introduction to the output format.
 
 ## License
 
-This project is licensed under [CC0 1.0 Universal](https://github.com/clingen-data-model/clinvar-gks/blob/main/LICENSE) (public domain dedication).
+This project is licensed under [CC0 1.0 Universal](https://github.com/clingen-data-model/clinvar-gks/blob/main/LICENSE) (public domain dedication). The output data carries the same terms as the source ClinVar data.

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,10 +17,10 @@ ClinVar-GKS addresses these challenges by transforming every ClinVar release int
 
 The pipeline processes the **entirety** of each ClinVar XML release:
 
-- **~2.8 million** variations with VRS-normalized alleles and locations
-- **~4.1 million** submitted clinical classifications (SCVs) across germline, somatic, and oncogenicity statement types
-- **~870,000** aggregate variation classifications (VCVs) with multi-layer aggregation
-- **~1.1 million** condition-level aggregate classifications (RCVs)
+- **Every variation** with VRS-normalized alleles and locations
+- **Every submitted clinical classification** (SCV) across germline, somatic, and oncogenicity statement types
+- **Every aggregate variation classification** (VCV) with multi-layer aggregation
+- **Every condition-level aggregate classification** (RCV)
 
 New releases are produced weekly, synchronized with ClinVar's release schedule.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -10,7 +10,7 @@ ClinVar-GKS addresses these challenges by transforming every ClinVar release int
 
 - **Normalized variant identifiers** — Every variant receives a computable [VRS](https://vrs.ga4gh.org/) identifier, enabling unambiguous cross-system matching
 - **Categorical variant representations** — Variants are represented as [Cat-VRS](https://cat-vrs.readthedocs.io/) categorical variants with defining allele constraints and expressions
-- **Structured classification statements** — Every submitted (SCV), aggregate (VCV), and condition-level (RCV) classification is represented as a [VA-Spec](https://va-spec.readthedocs.io/) statement with explicit propositions, evidence, and provenance
+- **Structured classification statements** — Every submitted (SCV), aggregate (VCV), and condition-level (RCV) classification is represented as a [VA-Spec](https://va-spec.ga4gh.org/) statement with explicit propositions, evidence, and provenance
 - **Semantic consistency** — Classifications, propositions, conditions, genes, and cross-references use standardized structures with typed references
 
 ## What It Covers

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,14 +15,26 @@ ClinVar-GKS addresses these challenges by transforming every ClinVar release int
 
 ## What It Covers
 
-The pipeline processes the **entirety** of each ClinVar XML release:
+The pipeline processes the **entirety** of each ClinVar XML release — every variation, submitted classification, and aggregate record is represented. While 100% of variant, SCV, VCV, and RCV records from the corresponding ClinVar XML release are included, some data types within ClinVar are not yet part of the v1 release.
 
-- **Every variation** with VRS-normalized alleles and locations
-- **Every submitted clinical classification** (SCV) across germline, somatic, and oncogenicity statement types
-- **Every aggregate variation classification** (VCV) with multi-layer aggregation
-- **Every condition-level aggregate classification** (RCV)
+| ClinVar Data Type | v1 Status |
+| --- | --- |
+| Variation Aggregate Classifications (VCVs) | Included |
+| Variation-Condition Aggregate Classifications (RCVs) | Included |
+| Germline and Somatic Submissions (SCVs) | Included |
+| Variations (incl. Genes, HGVS, SPDI and VCF extensions) | Included |
+| [Submitters](https://www.ncbi.nlm.nih.gov/clinvar/docs/submitter_list/) | Included |
+| Aggregate & Case-level observations ([example](https://www.ncbi.nlm.nih.gov/clinvar/variation/1185392/#new-submission-germline)) | Planned |
+| Functional data submissions ([example](https://www.ncbi.nlm.nih.gov/clinvar/variation/548447/#new-submission-functional-data)) | Planned |
 
-New releases are produced weekly, synchronized with ClinVar's release schedule.
+Items marked **Planned** are not currently included in the v1 release. If this data is requested by the community, it will be added as demand indicates.
+
+!!! note "Functional Data Submissions"
+    Functional data is submitted to ClinVar as an SCV and may or may not be associated with a germline or somatic classification record. Functional data SCVs are excluded from the v1 release regardless of whether they are linked to a classification SCV. They will be included in a future release when functional data support is added.
+
+Feedback and feature requests are welcome via the [GitHub issue tracker](https://github.com/clingen-data-model/clinvar-gks/issues).
+
+New releases are produced within a day or two after ClinVar's XML releases and are intended to be synchronized with ClinVar's release dates.
 
 ## Who It's For
 

--- a/docs/output-reference/cat-vrs.md
+++ b/docs/output-reference/cat-vrs.md
@@ -1,10 +1,22 @@
-# Categorical Variants
+# Variations
 
 ## Overview
 
-The `variation.jsonl.gz` file contains one JSON record per ClinVar variation that successfully resolved to a VRS identity. Each record is a `CategoricalVariant` conforming to the Cat-VRS specification — a higher-level grouping that associates a ClinVar variation with its resolved VRS allele or copy number variant, along with expressions, cross-references, and ClinVar metadata.
+The `variation` bundle section contains one record per ClinVar variation. Each record represents a ClinVar variation and its relationship to a resolved VRS genomic identity, along with expressions, cross-references, gene associations, and ClinVar metadata.
 
-This file is produced by the [Cat-VRS procedure](../pipeline/cat-vrs/index.md).
+ClinVar variations are represented using the GA4GH [Cat-VRS](https://cat-vrs.readthedocs.io/) (Categorical Variation) specification. Cat-VRS defines categorical variant types that group variants at a higher level than individual VRS alleles — bridging the gap between ClinVar's variation concept and VRS's precise genomic representations.
+
+This section is produced by the [Cat-VRS procedure](../pipeline/cat-vrs/index.md).
+
+### Variation Types
+
+ClinVar variations map to three Cat-VRS representation types:
+
+- **CanonicalAllele** — The vast majority of ClinVar variations. ClinVar identifies each variation by mapping submitted variant attributes to a GRCh38 genomic allele (falling back to GRCh37 or NCBI36 for historical data). This *defining allele* becomes the `DefiningAlleleConstraint`, and the same genomic allele generates the VRS allele referenced via `#/allele/`. See the [Cat-VRS CanonicalAllele](https://cat-vrs.readthedocs.io/) specification.
+
+- **CategoricalCnvCount / CategoricalCnvChange** — Copy number variants use a `DefiningLocationConstraint` following the same identification approach, with an additional `CopyCountConstraint` when an absolute copy count is provided, or a `CopyChangeConstraint` when only gain/loss is indicated.
+
+- **Generalized Categorical Variant** — Haplotypes, genotypes, and other complex or ambiguously defined variants that cannot yet be mapped to a specific VRS allele or location. These rely solely on the ClinVar variation ID to distinguish them. Work continues within the GA4GH GKS workstream to expand VRS and Cat-VRS coverage for these types as community need arises.
 
 ---
 
@@ -21,7 +33,7 @@ Each record is a `CategoricalVariant` with the following top-level fields:
 | `name` | string | Best available HGVS expression for the variant |
 | `constraints` | array | Defining constraints linking to the resolved VRS variant. See [Constraints](#constraints) |
 | `mappings` | array | Cross-references to external databases. See [Mappings](#mappings) |
-| `members` | array | JSON pointer references to the defining allele within `constraints` |
+| `members` | array | `#/allele/` references to the defining VRS allele (empty for generalized variants) |
 | `extensions` | array | ClinVar metadata and supplementary data. See [Extensions](#extensions) |
 
 </div>
@@ -30,50 +42,44 @@ Each record is a `CategoricalVariant` with the following top-level fields:
 
 ## Constraints
 
-The `constraints` array defines the relationship between the categorical variant and its resolved VRS representation. The constraint type depends on the variant class:
+The `constraints` array defines the relationship between the variation and its resolved VRS representation. The constraint type depends on the variant class:
 
-| Categorical Type | Constraint Type | Key Fields |
+| Variation Type | Constraint Type | Key Fields |
 | --- | --- | --- |
-| `CanonicalAllele` | `DefiningAlleleConstraint` | `allele` — a VRS `Allele` with `id`, `location`, `state`, and `expressions` |
-| `CategoricalCnvChange` | `DefiningLocationConstraint` + `CopyChangeConstraint` | `location` — a VRS `SequenceLocation`; `copyChange` — gain/loss designation |
-| `CategoricalCnvCount` | `DefiningLocationConstraint` + `CopyCountConstraint` | `location` — a VRS `SequenceLocation`; `copies` — integer or range |
+| CanonicalAllele | `DefiningAlleleConstraint` | `allele` — `#/allele/{id}` reference to a VRS Allele |
+| CategoricalCnvChange | `DefiningLocationConstraint` + `CopyChangeConstraint` | `location` — `#/location/{id}` reference; `copyChange` — gain/loss |
+| CategoricalCnvCount | `DefiningLocationConstraint` + `CopyCountConstraint` | `location` — `#/location/{id}` reference; `copies` — integer or range |
+| Generalized | None | No VRS constraint — identified by ClinVar variation ID only |
 
 ### Allele Constraint Example
 
-The `DefiningAlleleConstraint` contains a fully resolved VRS `Allele`:
+The `DefiningAlleleConstraint` references a VRS Allele in the `allele` bundle section:
 
 ```json
 {
   "type": "DefiningAlleleConstraint",
-  "allele": {
-    "id": "ga4gh:VA.PN-6_l2_yI1UPBRCtFnWkR52iZXKVJ8b",
-    "type": "Allele",
-    "name": "NC_000001.11:g.11128044_11128045del",
-    "digest": "PN-6_l2_yI1UPBRCtFnWkR52iZXKVJ8b",
-    "location": {
-      "id": "ga4gh:SL.5-SKfXZ941W7JbZW3UmQKtijyUfd6d7z",
-      "type": "SequenceLocation",
-      "sequenceReference": {
-        "type": "SequenceReference",
-        "refgetAccession": "SQ.Ya6Rs7DHhDeg7YaOSg1EoNi3U_nQ9SvO",
-        "residueAlphabet": "na",
-        "molecularType": "genomic"
-      },
-      "start": 11128043,
-      "end": 11128045
-    },
-    "state": {
-      "type": "ReferenceLengthExpression",
-      "length": 0,
-      "sequence": "",
-      "repeatSubunitLength": 2
-    },
-    "expressions": [
-      { "syntax": "hgvs.g", "value": "NC_000001.11:g.11128044_11128045del" },
-      { "syntax": "spdi", "value": "NC_000001.11:11128043:AT:ATAT" },
-      { "syntax": "gnomad", "value": "1-11128043-CAT-C" }
-    ]
-  }
+  "allele": "#/allele/ga4gh:VA.ELQCnIBGqaTl0AEE0Az18XZ2cgIHAQIY",
+  "relations": [
+    { "primaryCoding": { "code": "liftover_to", "system": "ga4gh-gks-term:allele-relation" } },
+    { "primaryCoding": { "code": "transcribed_to", "system": "http://www.sequenceontology.org" } }
+  ]
+}
+```
+
+### Location Constraint Example
+
+The `DefiningLocationConstraint` for copy number variants references a VRS Location:
+
+```json
+{
+  "type": "DefiningLocationConstraint",
+  "location": "#/location/ga4gh:SL.5-SKfXZ941W7JbZW3UmQKtijyUfd6d7z",
+  "matchCharacteristic": {
+    "primaryCoding": { "code": "is_within", "system": "ga4gh-gks-term:location-match" }
+  },
+  "relations": [
+    { "primaryCoding": { "code": "liftover_to", "system": "ga4gh-gks-term:allele-relation" } }
+  ]
 }
 ```
 
@@ -94,12 +100,9 @@ The `mappings` array contains cross-references to external databases. Each mappi
 ```json
 {
   "coding": {
-    "system": "https://www.ncbi.nlm.nih.gov/snp",
-    "code": "rs1570942058",
-    "iris": [
-      "https://identifiers.org/dbsnp:rs1570942058",
-      "https://www.ncbi.nlm.nih.gov/snp/rs1570942058"
-    ]
+    "system": "dbSNP",
+    "code": "1799945",
+    "iris": ["https://identifiers.org/dbsnp:rs1799945"]
   },
   "relation": "relatedMatch"
 }
@@ -115,17 +118,17 @@ Common extensions:
 
 | Extension Name | Value Type | Description |
 | --- | --- | --- |
-| `categorical variation type` | string | The Cat-VRS type — `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount` |
-| `clinvar variation type` | string | ClinVar's variant type (e.g., `Deletion`, `single nucleotide variant`) |
-| `clinvar variation subtype` | string | ClinVar's subclass type (e.g., `SimpleAllele`, `Haplotype`) |
-| `clinvar cytogenetic location` | string | Chromosomal band location (e.g., `1p36.22`) |
-| `clinvar assembly` | string | Reference genome assembly (e.g., `GRCh38`) |
-| `hgvs list` | array | All HGVS expressions with molecular consequences and MANE designations |
+| `categoricalVariationType` | string | The Cat-VRS type — `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount` |
+| `clinvarVariationType` | string | ClinVar's variant type (e.g., `Deletion`, `single nucleotide variant`) |
+| `clinvarSubclassType` | string | ClinVar's subclass type (e.g., `SimpleAllele`, `Haplotype`) |
+| `clinvarCytogeneticLocation` | string | Chromosomal band location (e.g., `1p36.22`) |
+| `clinvarGeneList` | array | Gene associations with `#/gene/` references, relationship type, and source |
+| `clinvarHgvsList` | array | All HGVS expressions with molecular consequences and MANE designations |
 
 ---
 
 ## Examples
 
-Annotated JSONC examples of categorical variant records are available in the repository:
+Annotated JSONC examples of variation records are available in the repository:
 
-- [Cat-VRS examples](https://github.com/clingen-data-model/clinvar-gks/tree/main/examples/cat-vrs) — `CanonicalAllele` records for ClinVar variations
+- [Cat-VRS examples](https://github.com/clingen-data-model/clinvar-gks/tree/main/examples/cat-vrs) — CanonicalAllele records for ClinVar variations

--- a/docs/output-reference/classes/index.md
+++ b/docs/output-reference/classes/index.md
@@ -8,48 +8,58 @@ This page provides a visual overview of how the classes relate to each other, wi
 
 ## Class Relationship Diagram
 
-The diagram below shows the major classes and their reference relationships. Arrows indicate which class references which — for example, a Variation references one or more Alleles via `#/allele/` pointers.
+The diagram below shows how the bundle classes relate to each other. Arrows indicate reference direction — for example, a Variation references its Allele members, and an SCV Statement references its Proposition.
 
 ```mermaid
-graph TD
-    subgraph Genomic
-        SR[SequenceReference]
-        LOC[Location]
-        AL[Allele]
-        G[Gene]
-        V[Variation]
+flowchart LR
+    subgraph "<b>Genomic</b>"
+        direction TB
+        SR(["SequenceReference<br/><small>SQ.{digest}</small>"])
+        LOC(["Location<br/><small>ga4gh:SL.{digest}</small>"])
+        AL(["Allele<br/><small>ga4gh:VA.{digest}</small>"])
+        G(["Gene<br/><small>ncbigene:{id}</small>"])
+        V(["<b>Variation</b><br/><small>clinvar:{id}</small>"])
     end
 
-    subgraph Clinical
-        COND[Condition]
-        CS[ConditionSet]
-        SUB[Submitter]
-        PROP[Proposition]
+    subgraph "<b>Clinical</b>"
+        direction TB
+        COND(["Condition<br/><small>clinvar.trait:{id}</small>"])
+        CS(["ConditionSet<br/><small>clinvar.traitset:{id}</small>"])
+        SUB(["Submitter<br/><small>clinvar.submitter:{id}</small>"])
+        PROP(["<b>Proposition</b><br/><small>{scv}-{CODE}</small>"])
     end
 
-    subgraph Statements
-        SCV[SCV Statement]
-        VCV[VCV Statement]
-        RCV[RCV Statement]
+    subgraph "<b>Statements</b>"
+        direction TB
+        SCV(["<b>SCV</b><br/><small>clinvar.submission:{id}.{ver}</small>"])
+        VCV(["<b>VCV</b><br/><small>{vcv}-{group}-{prop}-{level}</small>"])
+        RCV(["<b>RCV</b><br/><small>{rcv}-{group}-{prop}-{level}</small>"])
     end
 
-    LOC -->|sequenceReference| SR
-    AL -->|location| LOC
-    V -->|members| AL
-    V -->|gene extensions| G
-    CS -->|condition refs| COND
-    PROP -->|subjectVariant| V
-    PROP -->|objectCondition| COND
-    PROP -->|objectCondition| CS
-    SCV -->|proposition| PROP
-    SCV -->|contributions| SUB
-    VCV -->|proposition| PROP
-    VCV -->|evidenceItems| SCV
-    VCV -->|evidenceItems| VCV
-    RCV -->|proposition| PROP
-    RCV -->|evidenceItems| SCV
-    RCV -->|evidenceItems| RCV
+    %% Genomic chain
+    LOC -- "#/sequenceReference/" --> SR
+    AL -- "#/location/" --> LOC
+    V -- "#/allele/" --> AL
+    V -. "#/gene/" .-> G
+
+    %% Clinical links
+    CS -- "#/condition/" --> COND
+    PROP -- "#/variation/" --> V
+    PROP -- "#/condition/" --> COND
+    PROP -. "#/conditionSet/" .-> CS
+
+    %% Statement links
+    SCV -- "#/proposition/" --> PROP
+    SCV -- "#/submitter/" --> SUB
+    VCV -- "#/proposition/" --> PROP
+    VCV -- "#/scv/" --> SCV
+    VCV -. "#/vcv/" .-> VCV
+    RCV -- "#/proposition/" --> PROP
+    RCV -- "#/scv/" --> SCV
+    RCV -. "#/rcv/" .-> RCV
 ```
+
+Solid arrows represent primary references. Dashed arrows represent optional or self-referencing relationships (e.g., VCV statements can reference lower-level VCV groupings, and genes are referenced from variation extensions).
 
 ---
 

--- a/docs/output-reference/classes/index.md
+++ b/docs/output-reference/classes/index.md
@@ -1,0 +1,142 @@
+# Data Model
+
+The ClinVar-GKS release file organizes data into dictionary sections, each containing objects of a specific class. These classes form a directed graph of relationships — variants reference alleles, alleles reference locations, statements reference propositions, and so on.
+
+This page provides a visual overview of how the classes relate to each other, with links to detailed documentation for each class.
+
+---
+
+## Class Relationship Diagram
+
+The diagram below shows the major classes and their reference relationships. Arrows indicate which class references which — for example, a Variation references one or more Alleles via `#/allele/` pointers.
+
+```mermaid
+graph TD
+    subgraph Genomic
+        SR[SequenceReference]
+        LOC[Location]
+        AL[Allele]
+        G[Gene]
+        V[Variation]
+    end
+
+    subgraph Clinical
+        COND[Condition]
+        CS[ConditionSet]
+        SUB[Submitter]
+        PROP[Proposition]
+    end
+
+    subgraph Statements
+        SCV[SCV Statement]
+        VCV[VCV Statement]
+        RCV[RCV Statement]
+    end
+
+    LOC -->|sequenceReference| SR
+    AL -->|location| LOC
+    V -->|members| AL
+    V -->|gene extensions| G
+    CS -->|condition refs| COND
+    PROP -->|subjectVariant| V
+    PROP -->|objectCondition| COND
+    PROP -->|objectCondition| CS
+    SCV -->|proposition| PROP
+    SCV -->|contributions| SUB
+    VCV -->|proposition| PROP
+    VCV -->|evidenceItems| SCV
+    VCV -->|evidenceItems| VCV
+    RCV -->|proposition| PROP
+    RCV -->|evidenceItems| SCV
+    RCV -->|evidenceItems| RCV
+```
+
+---
+
+## Genomic Classes
+
+These classes represent the variant and its genomic context.
+
+### [SequenceReference](sequence-reference.md)
+
+A reference sequence (chromosome, transcript, or protein) identified by its refget accession. Carries molecule type, residue alphabet, and assembly information.
+
+**Dictionary section:** `sequenceReference` — keyed by refget accession (e.g., `SQ.0iKlIQk2oZLoeOG9P1riRU6hvL5Ux8TV`)
+
+### [Location](location.md)
+
+A position or range on a sequence reference, identified by a VRS sequence location digest. References its parent sequence via `#/sequenceReference/`.
+
+**Dictionary section:** `location` — keyed by VRS location ID (e.g., `ga4gh:SL.Eg_6kV6Bb4FMjm9kEolHZ_4NhU8lBEsZ`)
+
+### [Allele](allele.md)
+
+A specific sequence change at a location, identified by a VRS allele digest. Carries the alternate state, expressions (SPDI, HGVS, gnomAD), and references its location via `#/location/`.
+
+**Dictionary section:** `allele` — keyed by VRS allele ID (e.g., `ga4gh:VA.ELQCnIBGqaTl0AEE0Az18XZ2cgIHAQIY`)
+
+### [Gene](gene.md)
+
+A gene record with NCBI Entrez gene ID, HGNC ID, symbol, and identifier IRIs. Referenced from variation extensions via `#/gene/`.
+
+**Dictionary section:** `gene` — keyed by `ncbigene:{gene_id}` (e.g., `ncbigene:3077`)
+
+### [Variation](variation.md)
+
+A Cat-VRS categorical variant that groups a ClinVar variation with its defining VRS allele, constraints, cross-references, HGVS expressions, and gene associations. References alleles via `#/allele/` and genes via `#/gene/`.
+
+**Dictionary section:** `variation` — keyed by `clinvar:{variation_id}` (e.g., `clinvar:10`)
+
+---
+
+## Clinical Classes
+
+These classes represent the conditions, submitters, and propositions that support clinical classification statements.
+
+### [Condition](condition.md)
+
+A disease or phenotype concept from ClinVar's trait data, with MedGen primary coding and cross-references to OMIM, MONDO, HPO, Orphanet, and MeSH.
+
+**Dictionary section:** `condition` — keyed by `clinvar.trait:{trait_id}` (e.g., `clinvar.trait:9580`)
+
+### [ConditionSet](condition-set.md)
+
+A grouping of multiple conditions with a membership operator (AND or OR) and references to member conditions via `#/condition/`.
+
+**Dictionary section:** `conditionSet` — keyed by `clinvar.traitset:{trait_set_id}` (e.g., `clinvar.traitset:1234`)
+
+### [Submitter](submitter.md)
+
+A submitting organization identified by ClinVar submitter ID, with name and type.
+
+**Dictionary section:** `submitter` — keyed by `clinvar.submitter:{submitter_id}` (e.g., `clinvar.submitter:500139`)
+
+### [Proposition](proposition.md)
+
+A classification proposition defining what a statement asserts — the proposition type, predicate, subject variant (via `#/variation/`), and object condition (via `#/condition/` or `#/conditionSet/`). May also include gene context, mode of inheritance, and penetrance qualifiers.
+
+**Dictionary section:** `proposition` — keyed by proposition ID (e.g., `SCV001234567-PATH`, `VCV000012582.63-G-PATH-CP`)
+
+---
+
+## Statement Classes
+
+These classes represent the clinical classification statements at different levels of aggregation.
+
+### [SCV Statement](scv-statement.md)
+
+A submitted clinical classification (SCV) — the atomic unit of ClinVar data. Each SCV carries a classification, strength, direction, proposition reference, contributions with submitter references, evidence lines, citations, assertion method, and extensions with submitted condition provenance.
+
+**Dictionary section:** `scv` — keyed by `clinvar.submission:{scv_id}.{version}` (e.g., `clinvar.submission:SCV001234567.1`)
+
+### [VCV Statement](vcv-statement.md)
+
+A variation-level aggregate classification (VCV) — aggregates SCVs across a variation by classification grouping, priority (somatic tiers), and submission level contribution. Evidence lines reference contributing SCVs or lower-level VCV groupings.
+
+**Dictionary section:** `vcv` — keyed by the VCV layer ID (e.g., `VCV000012582.63-G-PATH-CP`)
+
+### [RCV Statement](rcv-statement.md)
+
+A condition-level aggregate classification (RCV) — follows the same aggregation structure as VCVs but scoped to a specific RCV accession (variation + condition combination).
+
+**Dictionary section:** `rcv` — keyed by the RCV layer ID (e.g., `RCV000012345.8-G-PATH-CP`)

--- a/docs/output-reference/classes/index.md
+++ b/docs/output-reference/classes/index.md
@@ -1,6 +1,6 @@
 # Data Model
 
-The ClinVar-GKS release file organizes data into dictionary sections, each containing objects of a specific class. These classes form a directed graph of relationships — variants reference alleles, alleles reference locations, statements reference propositions, and so on.
+The ClinVar-GKS release file organizes data into bundle sections, each containing objects of a specific class. These classes form a directed graph of relationships — variants reference alleles, alleles reference locations, statements reference propositions, and so on.
 
 This page provides a visual overview of how the classes relate to each other, with links to detailed documentation for each class.
 
@@ -61,31 +61,31 @@ These classes represent the variant and its genomic context.
 
 A reference sequence (chromosome, transcript, or protein) identified by its refget accession. Carries molecule type, residue alphabet, and assembly information.
 
-**Dictionary section:** `sequenceReference` — keyed by refget accession (e.g., `SQ.0iKlIQk2oZLoeOG9P1riRU6hvL5Ux8TV`)
+**Bundle section:** `sequenceReference` — keyed by refget accession (e.g., `SQ.0iKlIQk2oZLoeOG9P1riRU6hvL5Ux8TV`)
 
 ### [Location](location.md)
 
 A position or range on a sequence reference, identified by a VRS sequence location digest. References its parent sequence via `#/sequenceReference/`.
 
-**Dictionary section:** `location` — keyed by VRS location ID (e.g., `ga4gh:SL.Eg_6kV6Bb4FMjm9kEolHZ_4NhU8lBEsZ`)
+**Bundle section:** `location` — keyed by VRS location ID (e.g., `ga4gh:SL.Eg_6kV6Bb4FMjm9kEolHZ_4NhU8lBEsZ`)
 
 ### [Allele](allele.md)
 
 A specific sequence change at a location, identified by a VRS allele digest. Carries the alternate state, expressions (SPDI, HGVS, gnomAD), and references its location via `#/location/`.
 
-**Dictionary section:** `allele` — keyed by VRS allele ID (e.g., `ga4gh:VA.ELQCnIBGqaTl0AEE0Az18XZ2cgIHAQIY`)
+**Bundle section:** `allele` — keyed by VRS allele ID (e.g., `ga4gh:VA.ELQCnIBGqaTl0AEE0Az18XZ2cgIHAQIY`)
 
 ### [Gene](gene.md)
 
 A gene record with NCBI Entrez gene ID, HGNC ID, symbol, and identifier IRIs. Referenced from variation extensions via `#/gene/`.
 
-**Dictionary section:** `gene` — keyed by `ncbigene:{gene_id}` (e.g., `ncbigene:3077`)
+**Bundle section:** `gene` — keyed by `ncbigene:{gene_id}` (e.g., `ncbigene:3077`)
 
 ### [Variation](variation.md)
 
 A Cat-VRS categorical variant that groups a ClinVar variation with its defining VRS allele, constraints, cross-references, HGVS expressions, and gene associations. References alleles via `#/allele/` and genes via `#/gene/`.
 
-**Dictionary section:** `variation` — keyed by `clinvar:{variation_id}` (e.g., `clinvar:10`)
+**Bundle section:** `variation` — keyed by `clinvar:{variation_id}` (e.g., `clinvar:10`)
 
 ---
 
@@ -97,25 +97,25 @@ These classes represent the conditions, submitters, and propositions that suppor
 
 A disease or phenotype concept from ClinVar's trait data, with MedGen primary coding and cross-references to OMIM, MONDO, HPO, Orphanet, and MeSH.
 
-**Dictionary section:** `condition` — keyed by `clinvar.trait:{trait_id}` (e.g., `clinvar.trait:9580`)
+**Bundle section:** `condition` — keyed by `clinvar.trait:{trait_id}` (e.g., `clinvar.trait:9580`)
 
 ### [ConditionSet](condition-set.md)
 
 A grouping of multiple conditions with a membership operator (AND or OR) and references to member conditions via `#/condition/`.
 
-**Dictionary section:** `conditionSet` — keyed by `clinvar.traitset:{trait_set_id}` (e.g., `clinvar.traitset:1234`)
+**Bundle section:** `conditionSet` — keyed by `clinvar.traitset:{trait_set_id}` (e.g., `clinvar.traitset:1234`)
 
 ### [Submitter](submitter.md)
 
 A submitting organization identified by ClinVar submitter ID, with name and type.
 
-**Dictionary section:** `submitter` — keyed by `clinvar.submitter:{submitter_id}` (e.g., `clinvar.submitter:500139`)
+**Bundle section:** `submitter` — keyed by `clinvar.submitter:{submitter_id}` (e.g., `clinvar.submitter:500139`)
 
 ### [Proposition](proposition.md)
 
 A classification proposition defining what a statement asserts — the proposition type, predicate, subject variant (via `#/variation/`), and object condition (via `#/condition/` or `#/conditionSet/`). May also include gene context, mode of inheritance, and penetrance qualifiers.
 
-**Dictionary section:** `proposition` — keyed by proposition ID (e.g., `SCV001234567-PATH`, `VCV000012582.63-G-PATH-CP`)
+**Bundle section:** `proposition` — keyed by proposition ID (e.g., `SCV001234567-PATH`, `VCV000012582.63-G-PATH-CP`)
 
 ---
 
@@ -127,16 +127,16 @@ These classes represent the clinical classification statements at different leve
 
 A submitted clinical classification (SCV) — the atomic unit of ClinVar data. Each SCV carries a classification, strength, direction, proposition reference, contributions with submitter references, evidence lines, citations, assertion method, and extensions with submitted condition provenance.
 
-**Dictionary section:** `scv` — keyed by `clinvar.submission:{scv_id}.{version}` (e.g., `clinvar.submission:SCV001234567.1`)
+**Bundle section:** `scv` — keyed by `clinvar.submission:{scv_id}.{version}` (e.g., `clinvar.submission:SCV001234567.1`)
 
 ### [VCV Statement](vcv-statement.md)
 
 A variation-level aggregate classification (VCV) — aggregates SCVs across a variation by classification grouping, priority (somatic tiers), and submission level contribution. Evidence lines reference contributing SCVs or lower-level VCV groupings.
 
-**Dictionary section:** `vcv` — keyed by the VCV layer ID (e.g., `VCV000012582.63-G-PATH-CP`)
+**Bundle section:** `vcv` — keyed by the VCV layer ID (e.g., `VCV000012582.63-G-PATH-CP`)
 
 ### [RCV Statement](rcv-statement.md)
 
 A condition-level aggregate classification (RCV) — follows the same aggregation structure as VCVs but scoped to a specific RCV accession (variation + condition combination).
 
-**Dictionary section:** `rcv` — keyed by the RCV layer ID (e.g., `RCV000012345.8-G-PATH-CP`)
+**Bundle section:** `rcv` — keyed by the RCV layer ID (e.g., `RCV000012345.8-G-PATH-CP`)

--- a/docs/output-reference/classes/index.md
+++ b/docs/output-reference/classes/index.md
@@ -83,7 +83,15 @@ A gene record with NCBI Entrez gene ID, HGNC ID, symbol, and identifier IRIs. Re
 
 ### [Variation](variation.md)
 
-A Cat-VRS categorical variant that groups a ClinVar variation with its defining VRS allele, constraints, cross-references, HGVS expressions, and gene associations. References alleles via `#/allele/` and genes via `#/gene/`.
+A ClinVar variation — the central entity linking a genomic change to its clinical classifications. Each variation carries cross-references, HGVS expressions, gene associations, and a set of constraints that define its relationship to a VRS allele or location.
+
+ClinVar variations are represented using three GA4GH Cat-VRS recipes:
+
+- **CanonicalAllele** — The vast majority of ClinVar variations. ClinVar identifies each variation by mapping submitted variant attributes to a GRCh38 genomic allele (falling back to GRCh37 or NCBI36 for historical data). This *defining allele* becomes the `DefiningAlleleConstraint`, and the same genomic allele is used to generate the VRS representation referenced via `#/allele/`.
+
+- **CategoricalCnvCount / CategoricalCnvChange** — Copy number variants use a `DefiningLocationConstraint` following the same identification approach, with an additional `CopyCountConstraint` when ClinVar provides an absolute copy count, or a `CopyChangeConstraint` when only gain/loss is indicated.
+
+- **Generalized Categorical Variant** — Haplotypes, genotypes, and other complex or ambiguously defined variants that cannot yet be mapped to a specific VRS allele or location. These rely solely on the ClinVar variation ID to distinguish them. Work continues within the GA4GH GKS workstream to expand VRS and Cat-VRS coverage for these types as community need arises.
 
 **Bundle section:** `variation` — keyed by `clinvar:{variation_id}` (e.g., `clinvar:10`)
 

--- a/docs/output-reference/id-references.md
+++ b/docs/output-reference/id-references.md
@@ -1,181 +1,182 @@
-# ID References and Cross-File Resolution
+# ID References
 
 ## Overview
 
-The ClinVar-GKS output files use a system of typed identifiers to reference objects both within and across files. Some fields contain full embedded objects (inline), while others contain ID-only references that resolve to objects in a separate export file. This page documents all identifier formats, where they appear, and how to resolve cross-file references.
+The ClinVar-GKS bundle uses typed identifiers and `#/` JSON pointer references to link objects across bundle sections. This page documents all identifier formats, reference patterns, and how to resolve them.
 
 ---
 
 ## Identifier Namespaces
 
-All ClinVar-GKS identifiers use a prefix namespace to indicate the type of resource:
+All ClinVar-GKS identifiers use a prefix namespace to indicate the resource type:
 
 | Prefix | Resource Type | Format | Example |
 | --- | --- | --- | --- |
 | `clinvar:` | Variation | `clinvar:{variation_id}` | `clinvar:12582` |
 | `clinvar.submission:` | SCV submission | `clinvar.submission:SCV{id}.{version}` | `clinvar.submission:SCV001571657.2` |
 | `clinvar.submitter:` | Submitter organization | `clinvar.submitter:{submitter_id}` | `clinvar.submitter:508027` |
-| `ga4gh:` | VRS identity | `ga4gh:{type}.{digest}` | `ga4gh:VA.xXBYkzzu1AH0oyMKlbBtP2` |
+| `clinvar.trait:` | Condition / trait | `clinvar.trait:{trait_id}` | `clinvar.trait:9580` |
+| `clinvar.traitset:` | Condition set | `clinvar.traitset:{trait_set_id}` | `clinvar.traitset:1234` |
+| `ncbigene:` | Gene | `ncbigene:{gene_id}` | `ncbigene:3077` |
+| `ga4gh:` | VRS identity | `ga4gh:{type}.{digest}` | `ga4gh:VA.ELQCnIBGqaTl0AEE0Az18XZ2cgIHAQIY` |
+| `SQ.` | Sequence reference | `SQ.{digest}` | `SQ.0iKlIQk2oZLoeOG9P1riRU6hvL5Ux8TV` |
 
 VCV and RCV aggregate statement IDs use a hierarchical format without a namespace prefix — see [VCV Statement IDs](#vcv-statement-ids) and [RCV Statement IDs](#rcv-statement-ids).
 
 ---
 
-## Cross-File Reference Resolution
+## JSON Pointer References
 
-When a field contains an ID-only reference (rather than a full embedded object), the referenced object can be found in a specific export file by matching the `id` field.
+Objects reference each other using `#/{section}/{key}` strings. To resolve a reference:
 
-### Resolution Table
+1. Split the string on `/` — the second segment is the bundle section name, the third is the key
+2. Look up the key in the named section of the bundle
 
-| Reference Field | Appears In | ID Format | Resolves To | Target File |
-| --- | --- | --- | --- | --- |
-| `proposition.subjectVariant` | SCV statements (by-ref) | `clinvar:{variation_id}` | Categorical Variant record | `variation.jsonl.gz` |
-| `proposition.subjectVariant` | VCV statements | `clinvar:{variation_id}` | Categorical Variant record | `variation.jsonl.gz` |
-| `evidenceItems[].id` (leaf) | VCV statements | `clinvar.submission:SCV{id}.{ver}` | SCV Statement record | `scv_by_ref.jsonl.gz` |
-| `proposition.subjectVariant` | RCV statements | `clinvar:{variation_id}` | Categorical Variant record | `variation.jsonl.gz` |
-| `evidenceItems[].id` (leaf) | RCV statements | `clinvar.submission:SCV{id}.{ver}` | SCV Statement record | `scv_by_ref.jsonl.gz` |
-| `contributor.id` | SCV statements | `clinvar.submitter:{id}` | Submitter organization | Not exported as standalone — embedded in SCV records |
-| `constraints[].definingContext.id` | Categorical Variants | `ga4gh:{type}.{digest}` | VRS allele/copy number | Embedded within the same record |
+### Reference Patterns
+
+| Pattern | Example | Target Section |
+| --- | --- | --- |
+| `#/sequenceReference/{key}` | `#/sequenceReference/SQ.0iKlIQk2oZLoeOG9P1riRU6hvL5Ux8TV` | `sequenceReference` |
+| `#/location/{key}` | `#/location/ga4gh:SL.Eg_6kV6Bb4FMjm9kEolHZ_4NhU8lBEsZ` | `location` |
+| `#/allele/{key}` | `#/allele/ga4gh:VA.ELQCnIBGqaTl0AEE0Az18XZ2cgIHAQIY` | `allele` |
+| `#/gene/{key}` | `#/gene/ncbigene:3077` | `gene` |
+| `#/variation/{key}` | `#/variation/clinvar:10` | `variation` |
+| `#/condition/{key}` | `#/condition/clinvar.trait:9580` | `condition` |
+| `#/conditionSet/{key}` | `#/conditionSet/clinvar.traitset:1234` | `conditionSet` |
+| `#/submitter/{key}` | `#/submitter/clinvar.submitter:500139` | `submitter` |
+| `#/proposition/{key}` | `#/proposition/SCV001234567-PATH` | `proposition` |
+| `#/scv/{key}` | `#/scv/clinvar.submission:SCV001234567.1` | `scv` |
+| `#/vcv/{key}` | `#/vcv/VCV000012582.63-G-PATH-CP` | `vcv` |
+| `#/rcv/{key}` | `#/rcv/RCV000012345.8-G-PATH-CP` | `rcv` |
+
+### Where References Appear
+
+| Object Type | Field | References |
+| --- | --- | --- |
+| Location | `sequenceReference` | `#/sequenceReference/` |
+| Allele | `location` | `#/location/` |
+| Variation | `members[]` | `#/allele/` |
+| Variation | `constraints[].allele` | `#/allele/` |
+| Variation | `constraints[].location` | `#/location/` |
+| Variation | `extensions[].clinvarGeneList[].gene` | `#/gene/` |
+| Proposition | `subjectVariant` | `#/variation/` |
+| Proposition | `objectCondition` | `#/condition/` or `#/conditionSet/` |
+| SCV Statement | `proposition` | `#/proposition/` |
+| SCV Statement | `contributions[].contributor` | `#/submitter/` |
+| VCV Statement | `proposition` | `#/proposition/` |
+| VCV Statement | `evidenceLines[].evidenceItems[]` | `#/scv/` or `#/vcv/` |
+| RCV Statement | `proposition` | `#/proposition/` |
+| RCV Statement | `evidenceLines[].evidenceItems[]` | `#/scv/` or `#/rcv/` |
 
 ### Resolution Example
 
-A VCV statement's leaf-level evidence items contain ID references to SCV submissions:
-
-```json
-{
-  "type": "EvidenceLine",
-  "evidenceItems": [
-    {"id": "clinvar.submission:SCV001571657.2"},
-    {"id": "clinvar.submission:SCV000329383.7"}
-  ]
-}
-```
-
-To resolve these, look up each ID in `scv_by_ref.jsonl.gz`:
-
 ```python
-import gzip, json
+import gzip
+import json
 
-# Build an index of SCV records
-scv_index = {}
-with gzip.open("scv_by_ref.jsonl.gz", "rt") as f:
-    for line in f:
-        rec = json.loads(line)
-        scv_index[rec["id"]] = rec
+# Load the bundle
+with gzip.open("clinvar-gks-current.json.gz", "rt") as f:
+    bundle = json.load(f)
 
-# Resolve references from a VCV statement
-for evidence_item in vcv["evidenceLines"][0]["evidenceItems"]:
-    if "type" not in evidence_item:  # leaf-level ID reference
-        full_scv = scv_index.get(evidence_item["id"])
+def resolve(bundle, ref):
+    """Resolve a #/section/key reference to the target object."""
+    parts = ref.lstrip("#/").split("/", 1)
+    return bundle[parts[0]][parts[1]]
+
+# Look up a variation
+variant = bundle["variation"]["clinvar:10"]
+
+# Resolve its allele member
+allele = resolve(bundle, variant["members"][0])
+
+# Resolve the allele's location
+location = resolve(bundle, allele["location"])
+
+# Resolve the location's sequence reference
+seq_ref = resolve(bundle, location["sequenceReference"])
 ```
 
-Similarly, a variant reference in any statement resolves to a record in `variation.jsonl.gz`:
+---
 
-```python
-catvar_index = {}
-with gzip.open("variation.jsonl.gz", "rt") as f:
-    for line in f:
-        rec = json.loads(line)
-        catvar_index[rec["id"]] = rec
+## SCV Proposition IDs
 
-# Resolve from SCV or VCV
-variant = catvar_index.get(statement["proposition"]["subjectVariant"])
+SCV proposition IDs combine the SCV accession with an uppercase proposition type code:
+
+```text
+{scv_id}-{PROP_CODE}
 ```
+
+| Component | Description | Examples |
+| --- | --- | --- |
+| `scv_id` | SCV accession (without version) | `SCV001234567` |
+| `PROP_CODE` | Uppercase proposition type code | `PATH`, `ONCO`, `SCI`, `ASSOC`, `RF`, `DR`, `NP`, `OTH`, `PROT`, `AFF`, `CS`, `CONF`, `UNDEF` |
+
+Examples: `SCV001234567-PATH`, `SCV004565358-PROG`, `SCV004565358-TR`
+
+Target (somatic evidence line) propositions use the clinical impact assertion type codes: `PROG`, `DIAG`, `TR`.
 
 ---
 
 ## VCV Statement IDs
 
-VCV aggregate statements use a hierarchical ID format that reflects the aggregation layer. RCV statements follow the same patterns with an RCV accession -- see [RCV Statement IDs](#rcv-statement-ids). Each layer's ID is built by progressively stripping components from right to left:
+VCV aggregate statements use a hierarchical ID format reflecting the aggregation layer:
 
 | Layer | Format | Example |
 | --- | --- | --- |
-| L1 (Base) | `{VCV}.{ver}-{group}-{prop}-{level}[-{tier}]` | `VCV000012582.63-G-path-CP` |
-| L2 (Tier) | `{VCV}.{ver}-{group}-{prop}-{level}` | `VCV000012582.63-G-sci-CP` |
-| L3 (Submission Level) | `{VCV}.{ver}-{group}-{prop}` | `VCV000012582.63-G-path` |
-| L4 (Statement Group) | `{VCV}.{ver}-{group}` | `VCV000012582.63-G` |
+| Classification | `{VCV}.{ver}-{group}-{PROP}-{level}[-{TIER}]` | `VCV000012582.63-G-PATH-CP` |
+| Priority | `{VCV}.{ver}-{group}-{PROP}-{level}` | `VCV000012582.63-S-SCI-CP` |
+| Aggregate | `{VCV}.{ver}-{group}-{PROP}` | `VCV000012582.63-G-PATH` |
 
 Components:
 
-- **group** — statement group: `G` (Germline), `S` (Somatic)
-- **prop** — proposition type: `path` (Pathogenicity), `onco` (Oncogenicity), `sci` (Somatic Clinical Impact), `dr` (Drug Response), `np` (Not Provided), `assoc` (Association), `other` (Other)
+- **group** — statement group: `G` (Germline), `S` (Somatic), `O` (Oncogenicity)
+- **PROP** — proposition type code (uppercase): `PATH`, `ONCO`, `SCI`, `ASSOC`, etc.
 - **level** — submission level: `PG`, `EP`, `CP`, `NOCP`, `NOCL`, `FLAG`
-- **tier** — classification tier (somatic only), uppercase: `TIER 1`, `TIER 2`, etc.
-
-Within a VCV statement's nested evidence lines, each evidence item references the next lower layer by its ID. The top-level L4 statement references L3 statements, which reference L2 or L1 statements, which reference individual SCVs.
+- **TIER** — classification tier (somatic only, uppercase): `TIER 1`, `TIER 2`, etc.
 
 ---
 
 ## RCV Statement IDs
 
-RCV aggregate statements use the same hierarchical ID format as VCV, but with an RCV accession instead of a VCV accession:
+RCV aggregate statements follow the same pattern as VCV but with an RCV accession:
 
 | Layer | Format | Example |
 | --- | --- | --- |
-| L1 (Base) | `{RCV}.{ver}-{group}-{prop}-{level}[-{tier}]` | `RCV000012345.10-G-path-CP` |
-| L2 (Tier) | `{RCV}.{ver}-{group}-{prop}-{level}` | `RCV000012345.10-G-sci-CP` |
-| L3 (Submission Level) | `{RCV}.{ver}-{group}-{prop}` | `RCV000012345.10-G-path` |
-| L4 (Statement Group) | `{RCV}.{ver}-{group}` | `RCV000012345.10-G` |
+| Classification | `{RCV}.{ver}-{group}-{PROP}-{level}[-{TIER}]` | `RCV000012345.10-G-PATH-CP` |
+| Priority | `{RCV}.{ver}-{group}-{PROP}-{level}` | `RCV000012345.10-S-SCI-CP` |
+| Aggregate | `{RCV}.{ver}-{group}-{PROP}` | `RCV000012345.10-G-PATH` |
 
-The component abbreviations (group, prop, level, tier) are the same as those defined in [VCV Statement IDs](#vcv-statement-ids).
-
-### RCV Proposition IDs
-
-RCV proposition IDs use the RCV accession (without version) in a hyphen-separated format:
-
-| Layer | Format | Example |
-| --- | --- | --- |
-| L1 | `{rcv_accession}-{group}-{prop}[-{level}][-{tier}]` | `RCV000012345-G-path-CP` |
-| L2 | `{rcv_accession}-{group}-{prop}-{level}` | `RCV000012345-G-sci-CP` |
-| L3 | `{rcv_accession}-{group}-{prop}` | `RCV000012345-G-path` |
-| L4 | `{rcv_accession}-{group}` | `RCV000012345-G` |
-
-RCV proposition IDs are internal to the statement structure and not used for cross-file resolution.
+The component abbreviations are the same as VCV.
 
 ---
 
-## VCV Proposition IDs
+## VCV/RCV Proposition IDs
 
-Each VCV statement's `proposition.id` uses a dot-separated format parallel to the statement ID:
+VCV and RCV proposition IDs use the accession (without version) in the same layered format:
 
 | Layer | Format | Example |
 | --- | --- | --- |
-| L1 | `{variation_id}.{group}.{prop}.{level}[.{tier}]` | `12582.G.path.CP` |
-| L2 | `{variation_id}.{group}.{prop}.{level}` | `12582.G.sci.CP` |
-| L3 | `{variation_id}.{group}.{prop}` | `12582.G.path` |
-| L4 | `{variation_id}.{group}` | `12582.G` |
-
-Proposition IDs are internal to the statement structure and not used for cross-file resolution.
-
----
-
-## Inline vs By-Reference
-
-The pipeline produces some objects in both forms:
-
-| Object | Inline Location | By-Reference Location |
-| --- | --- | --- |
-| Categorical Variant | `scv_inline.jsonl.gz` (embedded in proposition) | `scv_by_ref.jsonl.gz` (ID reference to `variation.jsonl.gz`) |
-| SCV Statement | VCV nested evidence items (L1 PRE inlines full structure) | VCV leaf evidence items (ID reference to `scv_by_ref.jsonl.gz`) |
-| VCV Sub-Statement | VCV nested evidence lines (higher layers inline lower layers) | N/A — always inlined within parent |
-
-VCV statements use a mixed approach: the nested evidence structure fully inlines sub-statements at each layer, but the leaf-level evidence items (individual SCVs) are ID-only references.
+| Classification | `{accession}-{group}-{PROP}-{level}[-{TIER}]` | `VCV000012582-G-PATH-CP` |
+| Priority | `{accession}-{group}-{PROP}-{level}` | `VCV000012582-S-SCI-CP` |
+| Aggregate | `{accession}-{group}-{PROP}` | `VCV000012582-G-PATH` |
 
 ---
 
 ## External Cross-References
 
-Categorical Variant records contain `mappings` to external databases using standardized URL formats:
+Variation records contain `mappings` to external databases using standardized URL formats:
 
 | Database | URL Pattern |
 | --- | --- |
 | MedGen | `https://identifiers.org/medgen:{id}` |
-| OMIM | `https://identifiers.org/mim:{id}` |
+| OMIM | `http://www.omim.org/entry/{id}` |
 | HPO | `https://identifiers.org/{id}` |
 | MONDO | `https://identifiers.org/mondo:{id}` |
-| Orphanet | `https://identifiers.org/orphanet.ordo:Orphanet_{id}` |
+| Orphanet | `http://www.orpha.net/ORDO/Orphanet_{id}` |
 | dbSNP | `https://identifiers.org/dbsnp:rs{id}` |
 | ClinGen | `https://reg.clinicalgenome.org/.../by_caid?caid={id}` |
+| UniProtKB | `https://www.uniprot.org/uniprot/{id}` |
+| GTR | `https://www.ncbi.nlm.nih.gov/gtr/tests/{id}` |
 | PubMed | `https://pubmed.ncbi.nlm.nih.gov/{id}` |
 
-See the [gks_xref_iri_templates](../pipeline/cat-vrs/index.md) table for the complete list of URL template mappings.
+Condition records contain `mappings` to disease/phenotype databases (OMIM, MONDO, HPO, Orphanet, MeSH) and a `primaryCoding` from MedGen.

--- a/docs/output-reference/index.md
+++ b/docs/output-reference/index.md
@@ -60,4 +60,4 @@ The output conforms to these GA4GH standards:
 
 - **[VRS 2.0](https://vrs.ga4gh.org/)** — Variation Representation Specification for allele and copy number representations
 - **[Cat-VRS](https://cat-vrs.readthedocs.io/)** — Categorical Variation for grouping variants at a higher categorical level
-- **[VA-Spec](https://va-spec.readthedocs.io/)** — Variant Annotation Specification for clinical variant statements
+- **[VA-Spec](https://va-spec.ga4gh.org/)** — Variant Annotation Specification for clinical variant statements

--- a/docs/output-reference/index.md
+++ b/docs/output-reference/index.md
@@ -1,40 +1,56 @@
 # Output Reference
 
-The ClinVar-GKS pipeline produces several JSONL files distributed via a public Google Cloud Storage bucket. Each file contains one JSON record per line, compressed with gzip.
+The ClinVar-GKS pipeline produces a single compressed JSON file per release, containing all variant representations, clinical classification statements, and supporting reference data. This section documents the output from a **consumer perspective** — how the file is structured, what each section contains, and how to interpret the data.
 
-This section documents the JSON output from a **consumer perspective** — what each file contains, the structure of its records, and how to interpret the fields. For details on how these files are built, see the [Pipeline](../pipeline/index.md) documentation.
+For details on how the output is built, see the [Pipeline](../pipeline/index.md) documentation.
 
 ---
 
-## Output Files
+## Release Format
 
-| File | Content | Records | Pipeline Source |
+Each release is a single gzip-compressed JSON file (`.json.gz`) containing a root-level object with **dictionary sections**. Each section is a keyed collection — the key is the object's unique identifier, and the value is the complete object.
+
+See [Output Format Overview](overview.md) for a detailed guide to the dictionary structure, reference patterns, and how to navigate between sections.
+
+---
+
+## Sections
+
+| Section | Content | Key Format | Records |
 | --- | --- | --- | --- |
-| `variation.jsonl.gz` | [Categorical Variants](cat-vrs.md) | One per ClinVar variation with a resolved VRS identity | `gks_catvar` table via [Cat-VRS](../pipeline/cat-vrs/index.md) |
-| `scv_by_ref.jsonl.gz` | [SCV Statements (by reference)](scv-statements.md#by-reference-format) | One per submitted clinical assertion | `gks_scv_statement_by_ref` table via [SCV Statements](../pipeline/scv-statements/index.md) |
-| `scv_inline.jsonl.gz` | [SCV Statements (inline)](scv-statements.md#inline-format) | One per submitted clinical assertion | `gks_scv_statement_inline` table via [SCV Statements](../pipeline/scv-statements/index.md) |
-| `vcv.jsonl.gz` | [VCV Statements](vcv-statements.md) | One per variant-level aggregate classification | `gks_vcv_statement` table via [VCV Statements](../pipeline/vcv-statements/index.md) |
-| `rcv.jsonl.gz` | [RCV Statements](rcv-statements.md) | One per condition-level aggregate classification | `gks_rcv_statement` table via [RCV Statements](../pipeline/rcv-statements/index.md) |
+| [`sequenceReference`](cat-vrs.md) | VRS sequence references | `SQ.{digest}` | ~200 |
+| [`location`](cat-vrs.md) | VRS sequence locations | `ga4gh:SL.{digest}` | ~4M |
+| [`allele`](cat-vrs.md) | VRS alleles with expressions | `ga4gh:VA.{digest}` | ~4.5M |
+| [`gene`](cat-vrs.md) | Gene records | `ncbigene:{id}` | ~90K |
+| [`variation`](cat-vrs.md) | Cat-VRS categorical variants | `clinvar:{variation_id}` | ~2.8M |
+| `condition` | Trait/disease concepts | `clinvar.trait:{id}` | ~40K |
+| `conditionSet` | Multi-condition groupings | `clinvar.traitset:{id}` | ~30K |
+| `submitter` | Submitting organizations | `clinvar.submitter:{id}` | ~2.5K |
+| [`proposition`](scv-statements.md) | Classification propositions | `{scv_id}-{CODE}` / `{vcv_id}-{group}-{prop}-{level}` | ~4M+ |
+| [`scv`](scv-statements.md) | Submitted classifications | `clinvar.submission:{scv_id}.{version}` | ~4.1M |
+| [`vcv`](vcv-statements.md) | Variation-level aggregates | `{vcv_id}-{group}-{prop}-{level}` | ~870K |
+| [`rcv`](rcv-statements.md) | Condition-level aggregates | `{rcv_id}-{group}-{prop}-{level}` | ~1.1M |
 
 ---
 
 ## Format Conventions
 
-All output files share these conventions:
-
-- **JSONL** — one JSON object per line, no surrounding array
-- **gzip compressed** — decompress with `gunzip` or read directly with libraries that support gzip streams
-- **Null stripping** — null-valued fields and empty arrays are omitted from the output
+- **Null stripping** — null-valued fields and empty arrays/objects are omitted from the output
 - **GA4GH identifiers** — VRS identifiers use the `ga4gh:` prefix (e.g., `ga4gh:VA.abc123`)
 - **ClinVar identifiers** — ClinVar-scoped identifiers use the `clinvar:` prefix (e.g., `clinvar:12345`)
+- **JSON pointer references** — objects reference each other using `#/{section}/{key}` strings (e.g., `#/allele/ga4gh:VA.abc123`)
 
 ---
 
-## Cross-File References
+## Cross-Section References
 
-Records in different output files reference each other by ID. For example, a VCV or RCV statement's leaf-level evidence items contain `{"id": "clinvar.submission:SCV000123.1"}` references that resolve to full SCV records in `scv_by_ref.jsonl.gz`, and `proposition.subjectVariant` references resolve to categorical variants in `variation.jsonl.gz`.
+Objects reference each other using `#/` JSON pointer strings rather than embedding full objects. This keeps the file compact and avoids duplication. For example:
 
-See [ID References and Cross-File Resolution](id-references.md) for the complete reference resolution guide, identifier formats, and code examples.
+- A **variation** references its allele as `#/allele/ga4gh:VA.abc123`
+- An **SCV statement** references its proposition as `#/proposition/SCV001234567-PATH`
+- A **VCV evidence line** references its contributing SCVs as `#/scv/clinvar.submission:SCV001234567.1`
+
+See [ID References](id-references.md) for the complete reference format guide, identifier patterns, and resolution rules.
 
 ---
 

--- a/docs/output-reference/index.md
+++ b/docs/output-reference/index.md
@@ -8,9 +8,9 @@ For details on how the output is built, see the [Pipeline](../pipeline/index.md)
 
 ## Release Format
 
-Each release is a single gzip-compressed JSON file (`.json.gz`) containing a root-level object with **dictionary sections**. Each section is a keyed collection — the key is the object's unique identifier, and the value is the complete object.
+Each release is a single gzip-compressed JSON file (`.json.gz`) containing a root-level object with **bundle sections**. Each section is a keyed collection — the key is the object's unique identifier, and the value is the complete object.
 
-See [Output Format Overview](overview.md) for a detailed guide to the dictionary structure, reference patterns, and how to navigate between sections.
+See [Output Format Overview](overview.md) for a detailed guide to the bundle structure, reference patterns, and how to navigate between sections.
 
 ---
 

--- a/docs/output-reference/index.md
+++ b/docs/output-reference/index.md
@@ -16,20 +16,20 @@ See [Output Format Overview](overview.md) for a detailed guide to the dictionary
 
 ## Sections
 
-| Section | Content | Key Format | Records |
-| --- | --- | --- | --- |
-| [`sequenceReference`](cat-vrs.md) | VRS sequence references | `SQ.{digest}` | ~200 |
-| [`location`](cat-vrs.md) | VRS sequence locations | `ga4gh:SL.{digest}` | ~4M |
-| [`allele`](cat-vrs.md) | VRS alleles with expressions | `ga4gh:VA.{digest}` | ~4.5M |
-| [`gene`](cat-vrs.md) | Gene records | `ncbigene:{id}` | ~90K |
-| [`variation`](cat-vrs.md) | Cat-VRS categorical variants | `clinvar:{variation_id}` | ~2.8M |
-| `condition` | Trait/disease concepts | `clinvar.trait:{id}` | ~40K |
-| `conditionSet` | Multi-condition groupings | `clinvar.traitset:{id}` | ~30K |
-| `submitter` | Submitting organizations | `clinvar.submitter:{id}` | ~2.5K |
-| [`proposition`](scv-statements.md) | Classification propositions | `{scv_id}-{CODE}` / `{vcv_id}-{group}-{prop}-{level}` | ~4M+ |
-| [`scv`](scv-statements.md) | Submitted classifications | `clinvar.submission:{scv_id}.{version}` | ~4.1M |
-| [`vcv`](vcv-statements.md) | Variation-level aggregates | `{vcv_id}-{group}-{prop}-{level}` | ~870K |
-| [`rcv`](rcv-statements.md) | Condition-level aggregates | `{rcv_id}-{group}-{prop}-{level}` | ~1.1M |
+| Section | Content | Key Format |
+| --- | --- | --- |
+| [`sequenceReference`](cat-vrs.md) | VRS sequence references | `SQ.{digest}` |
+| [`location`](cat-vrs.md) | VRS sequence locations | `ga4gh:SL.{digest}` |
+| [`allele`](cat-vrs.md) | VRS alleles with expressions | `ga4gh:VA.{digest}` |
+| [`gene`](cat-vrs.md) | Gene records | `ncbigene:{id}` |
+| [`variation`](cat-vrs.md) | Cat-VRS categorical variants | `clinvar:{variation_id}` |
+| `condition` | Trait/disease concepts | `clinvar.trait:{id}` |
+| `conditionSet` | Multi-condition groupings | `clinvar.traitset:{id}` |
+| `submitter` | Submitting organizations | `clinvar.submitter:{id}` |
+| [`proposition`](scv-statements.md) | Classification propositions | `{scv_id}-{CODE}` / `{vcv_id}-{group}-{prop}-{level}` |
+| [`scv`](scv-statements.md) | Submitted classifications | `clinvar.submission:{scv_id}.{version}` |
+| [`vcv`](vcv-statements.md) | Variation-level aggregates | `{vcv_id}-{group}-{prop}-{level}` |
+| [`rcv`](rcv-statements.md) | Condition-level aggregates | `{rcv_id}-{group}-{prop}-{level}` |
 
 ---
 

--- a/docs/output-reference/overview.md
+++ b/docs/output-reference/overview.md
@@ -1,0 +1,134 @@
+# Output Format Overview
+
+The ClinVar-GKS release file uses a **bundled dictionary format** — a single JSON object with named sections at the root level. Each section is a keyed dictionary where the key is the object's unique identifier and the value is the complete object.
+
+This design eliminates duplication (a sequence reference shared by thousands of locations appears once), keeps individual objects compact, and enables efficient lookups by ID.
+
+---
+
+## Structure
+
+```json
+{
+  "sequenceReference": { "<key>": { ... }, ... },
+  "location":          { "<key>": { ... }, ... },
+  "allele":            { "<key>": { ... }, ... },
+  "gene":              { "<key>": { ... }, ... },
+  "variation":         { "<key>": { ... }, ... },
+  "condition":         { "<key>": { ... }, ... },
+  "conditionSet":      { "<key>": { ... }, ... },
+  "submitter":         { "<key>": { ... }, ... },
+  "proposition":       { "<key>": { ... }, ... },
+  "scv":               { "<key>": { ... }, ... },
+  "vcv":               { "<key>": { ... }, ... },
+  "rcv":               { "<key>": { ... }, ... }
+}
+```
+
+---
+
+## Sections
+
+### Genomic Data Sections
+
+These sections contain the VRS and Cat-VRS variant data:
+
+**`sequenceReference`** — Reference sequences (chromosomes, transcripts) with refget accessions, molecule type, and assembly information. Keyed by refget accession (e.g., `SQ.0iKlIQk2oZLoeOG9P1riRU6hvL5Ux8TV`).
+
+**`location`** — Sequence locations with start/end coordinates. Each location references its sequence via `#/sequenceReference/{key}`. Keyed by VRS location ID (e.g., `ga4gh:SL.Eg_6kV6Bb4FMjm9kEolHZ_4NhU8lBEsZ`).
+
+**`allele`** — VRS alleles with state, expressions (SPDI, HGVS, gnomAD), and copy number data. Each allele references its location via `#/location/{key}`. Keyed by VRS allele ID (e.g., `ga4gh:VA.ELQCnIBGqaTl0AEE0Az18XZ2cgIHAQIY`).
+
+**`gene`** — Gene records with NCBI gene ID, HGNC ID, symbol, and identifier IRIs. Keyed by `ncbigene:{gene_id}` (e.g., `ncbigene:3077`).
+
+**`variation`** — Cat-VRS categorical variants linking ClinVar variation IDs to their VRS alleles, constraints, cross-references, HGVS expressions, and gene associations. Each variation references its members via `#/allele/{key}` and genes via `#/gene/{key}`. Keyed by `clinvar:{variation_id}` (e.g., `clinvar:10`).
+
+### Clinical Data Sections
+
+These sections contain the condition, submitter, and proposition reference data:
+
+**`condition`** — Trait and disease concepts from ClinVar, with MedGen primary coding and cross-references to OMIM, MONDO, HPO, Orphanet, and MeSH. Keyed by `clinvar.trait:{trait_id}` (e.g., `clinvar.trait:9580`).
+
+**`conditionSet`** — Multi-condition groupings with member condition references and a membership operator (AND or OR). Keyed by `clinvar.traitset:{trait_set_id}` (e.g., `clinvar.traitset:1234`).
+
+**`submitter`** — Submitting organizations with name and identifier. Keyed by `clinvar.submitter:{submitter_id}` (e.g., `clinvar.submitter:500139`).
+
+**`proposition`** — Classification propositions defining what a statement asserts — the proposition type, predicate, subject variant, and object condition. Contains SCV, VCV, and RCV propositions in a single merged section. Keyed by proposition ID (e.g., `SCV001234567-PATH` for SCVs, `VCV000012582.63-G-PATH-CP` for VCVs).
+
+### Statement Sections
+
+These sections contain the clinical classification statements:
+
+**`scv`** — Submitted clinical classification statements. Each SCV carries a classification, strength, direction, proposition reference, contributions (with submitter references), evidence lines, citations, assertion method, and extensions with submitted condition provenance. Keyed by `clinvar.submission:{scv_id}.{version}`.
+
+**`vcv`** — Variation-level aggregate classification statements. VCVs aggregate SCVs across a variation by classification, priority (somatic tiers), and submission level contribution. Evidence lines reference contributing SCVs via `#/scv/` or lower-level VCV groupings via `#/vcv/`. Keyed by the VCV layer ID.
+
+**`rcv`** — Condition-level aggregate classification statements. RCVs follow the same aggregation structure as VCVs but are scoped to a specific RCV accession (variation + condition). Evidence lines reference SCVs and lower-level RCV groupings.
+
+---
+
+## JSON Pointer References
+
+Objects reference each other using `#/{section}/{key}` strings instead of embedding full objects inline. This keeps the file compact and enables consumers to resolve references by looking up the key in the named section.
+
+### Reference Patterns
+
+| Pattern | Example | Resolves To |
+| --- | --- | --- |
+| `#/sequenceReference/{key}` | `#/sequenceReference/SQ.0iKlIQk2oZLoeOG9P1riRU6hvL5Ux8TV` | Sequence reference object |
+| `#/location/{key}` | `#/location/ga4gh:SL.Eg_6kV6Bb4FMjm9kEolHZ_4NhU8lBEsZ` | Sequence location object |
+| `#/allele/{key}` | `#/allele/ga4gh:VA.ELQCnIBGqaTl0AEE0Az18XZ2cgIHAQIY` | VRS allele object |
+| `#/gene/{key}` | `#/gene/ncbigene:3077` | Gene object |
+| `#/variation/{key}` | `#/variation/clinvar:10` | Categorical variant object |
+| `#/condition/{key}` | `#/condition/clinvar.trait:9580` | Condition object |
+| `#/conditionSet/{key}` | `#/conditionSet/clinvar.traitset:1234` | Condition set object |
+| `#/submitter/{key}` | `#/submitter/clinvar.submitter:500139` | Submitter object |
+| `#/proposition/{key}` | `#/proposition/SCV001234567-PATH` | Proposition object |
+| `#/scv/{key}` | `#/scv/clinvar.submission:SCV001234567.1` | SCV statement object |
+| `#/vcv/{key}` | `#/vcv/VCV000012582.63-G-PATH-CP` | VCV statement object |
+| `#/rcv/{key}` | `#/rcv/RCV000012345.8-G-PATH-CP` | RCV statement object |
+
+### Resolving References
+
+To resolve a reference string like `#/allele/ga4gh:VA.abc123`:
+
+1. Split on `/` — the second segment is the section name (`allele`), the third is the key (`ga4gh:VA.abc123`)
+2. Look up the key in the named section of the root object
+3. The value at that key is the resolved object
+
+### Reference Depth
+
+References are **one level deep** — a resolved object may itself contain references, but those are always to other root-level sections, never nested references within references. A consumer can fully resolve any object by following at most 2-3 hops (e.g., variation → allele → location → sequenceReference).
+
+---
+
+## MappableConcept Pattern
+
+Several fields across statements use a **MappableConcept** structure — a typed object with a display name, optional primary coding, and optional extensions:
+
+```json
+{
+  "conceptType": "Classification",
+  "name": "Pathogenic",
+  "primaryCoding": {
+    "code": "pathogenic",
+    "system": "ACMG Guidelines, 2015"
+  },
+  "extensions": [ ... ]
+}
+```
+
+Fields that use this pattern:
+
+- **`classification`** — the clinical significance label (`conceptType: "Classification"`)
+- **`strength`** — the evidence strength (`conceptType: "Strength"`)
+- **`evidenceOutcome`** — the evidence line outcome (`conceptType: "Outcome"`)
+- **`strengthOfEvidenceProvided`** — the evidence line strength (`conceptType: "Strength"`)
+
+The `conceptType` identifies the kind of concept. The `name` is the human-readable display value. The `primaryCoding` provides a machine-readable code and system when available. Not all instances carry `primaryCoding` — aggregate VCV/RCV classifications, for example, may only have `conceptType` and `name`.
+
+---
+
+## Future: Inlining Tool
+
+The bundled dictionary format is designed to support a community tool that converts the single compressed file into **inlined output** at various levels of detail — from complete (all references resolved inline) to minimal (references only). This tool is under development and will be documented here when available.

--- a/docs/output-reference/overview.md
+++ b/docs/output-reference/overview.md
@@ -41,7 +41,7 @@ These sections contain the VRS and Cat-VRS variant data:
 
 **`gene`** — Gene records with NCBI gene ID, HGNC ID, symbol, and identifier IRIs. Keyed by `ncbigene:{gene_id}` (e.g., `ncbigene:3077`).
 
-**`variation`** — Cat-VRS categorical variants linking ClinVar variation IDs to their VRS alleles, constraints, cross-references, HGVS expressions, and gene associations. Each variation references its members via `#/allele/{key}` and genes via `#/gene/{key}`. Keyed by `clinvar:{variation_id}` (e.g., `clinvar:10`).
+**`variation`** — ClinVar variations with their defining constraints, cross-references, HGVS expressions, and gene associations. Most variations are represented as CanonicalAlleles with a defining VRS allele (via `#/allele/`); copy number variants use a defining location (via `#/location/`); complex variants use a generalized representation. Keyed by `clinvar:{variation_id}` (e.g., `clinvar:10`).
 
 ### Clinical Data Sections
 

--- a/docs/output-reference/overview.md
+++ b/docs/output-reference/overview.md
@@ -1,6 +1,6 @@
 # Output Format Overview
 
-The ClinVar-GKS release file uses a **bundled dictionary format** — a single JSON object with named sections at the root level. Each section is a keyed dictionary where the key is the object's unique identifier and the value is the complete object.
+The ClinVar-GKS release file uses a **bundle format** — a single JSON object with named sections at the root level. A bundle is a dictionary-style approach to organizing a large amount of data across heterogeneous classes in a single file, where each section is a keyed collection of objects of the same class. The key is the object's unique identifier, and the value is the complete object.
 
 This design eliminates duplication (a sequence reference shared by thousands of locations appears once), keeps individual objects compact, and enables efficient lookups by ID.
 
@@ -131,4 +131,4 @@ The `conceptType` identifies the kind of concept. The `name` is the human-readab
 
 ## Future: Inlining Tool
 
-The bundled dictionary format is designed to support a community tool that converts the single compressed file into **inlined output** at various levels of detail — from complete (all references resolved inline) to minimal (references only). This tool is under development and will be documented here when available.
+The bundle format is designed to support a community tool that converts the single compressed file into **inlined output** at various levels of detail — from complete (all references resolved inline) to minimal (references only). This tool is under development and will be documented here when available.

--- a/docs/output-reference/rcv-statements.md
+++ b/docs/output-reference/rcv-statements.md
@@ -2,14 +2,11 @@
 
 ## Overview
 
-The RCV statement output contains one JSON record per condition-level aggregate classification. Each record is a `Statement` that aggregates individual SCV submissions for the same variant **and condition** into a hierarchical summary — combining classifications across submission levels to produce a single condition-specific result.
+The `rcv` bundle section contains one record per condition-level aggregate classification. Each record is a `Statement` that aggregates individual SCV submissions for the same variant **and condition** into a hierarchical summary — combining classifications across submission levels to produce a single condition-specific result.
 
-RCV statements differ from VCV statements in two important ways:
+RCV statements differ from VCV statements in one important way: **condition-scoped aggregation** — each RCV is scoped to a specific condition (identified by `trait_set_id`), whereas VCV statements aggregate across all conditions for a variant.
 
-1. **Condition-scoped aggregation** — each RCV is scoped to a specific condition (identified by `trait_set_id`), whereas VCV statements aggregate across all conditions for a variant.
-2. **Condition-only proposition object** — the proposition uses `objectCondition` containing just the condition (sourced directly from the SCV's actual condition or conditionSet), without a classification wrapped alongside it. PG and EP are independent submission levels in RCV.
-
-RCV statements are produced by the [RCV Procedures](../pipeline/rcv-statements/rcv-proc.md) and serialized via the JSON proc. The output table is `gks_rcv_statement`.
+RCV statements use `#/` references for propositions, contributing SCVs, and lower-level RCV groupings. They are produced by the [RCV Procedures](../pipeline/rcv-statements/rcv-proc.md).
 
 ---
 
@@ -21,145 +18,101 @@ Each record is a `Statement` with the following top-level fields:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `id` | string | RCV accession with version and aggregation path — e.g., `RCV001781420.1-G-PATH` |
+| `id` | string | RCV layer ID — e.g., `RCV001781420.1-G-PATH-CP` |
 | `type` | string | Always `Statement` |
-| `confidence` | string | The submission level label (e.g., `"expert panel"`, `"assertion criteria provided"`) |
-| `direction` | string | Derived from the aggregate classification label; passed through from the contributing SCV for single-SCV aggregations |
-| `strength` | string | Derived from the aggregate classification label; passed through from the contributing SCV for single-SCV aggregations |
-| `classification` | object | Aggregate classification label as MappableConcept. See [Classification](#classification) |
-| `proposition` | object | The aggregate proposition with variant, objectCondition, and SCV-matching type/predicate. See [Proposition](#proposition) |
+| `proposition` | string | `#/proposition/{id}` reference to the aggregate proposition |
+| `classification` | object | MappableConcept — the aggregate classification label. See [Classification](#classification) |
+| `strength` | object | MappableConcept — the aggregate evidence strength |
+| `direction` | string | `supports`, `disputes`, or `neutral` — derived from the aggregate classification |
+| `confidence` | string | Submission level label (e.g., `criteria provided`, `expert panel`) |
 | `extensions` | array | Aggregate metadata — `clinvarReviewStatus` |
-| `evidenceLines` | array | Contributing and non-contributing evidence from lower aggregation layers |
+| `evidenceLines` | array | Contributing and non-contributing evidence. See [Evidence Lines](#evidence-lines) |
 
 </div>
 
-Like VCV, RCV statements use only `classification` at every layer. PG and EP are independent submission levels.
+The `classification`, `strength`, `direction`, and `confidence` fields follow the same structure and rules as [VCV Statements](vcv-statements.md).
 
 ---
 
 ## Classification
 
-RCV statements always use a single `classification` containing the aggregate classification label. The label format depends on the proposition type and submission level.
-
-### Standard format
-
-For most proposition types (pathogenicity, oncogenicity, association, etc.), the label is the aggregated label from contributing SCVs (e.g., `Pathogenic/Likely pathogenic`, `Conflicting classifications of pathogenicity`).
+RCV statements use the same MappableConcept classification as VCV:
 
 ```json
 {
-  "classification": {
-    "conceptType": "Classification",
-    "name": "Pathogenic/Likely pathogenic",
-    "extension": [
-      {"name": "conflictingExplanation", "value": "Pathogenic(3); Likely pathogenic(2)"}
-    ]
-  }
+  "conceptType": "Classification",
+  "name": "Pathogenic/Likely pathogenic",
+  "extensions": [
+    {"name": "conflictingExplanation", "value": "Pathogenic(3); Likely pathogenic(2)"}
+  ]
 }
 ```
 
-### Somatic Clinical Impact format
-
-For somatic clinical impact (SCI) propositions, the RCV label includes the clinical impact assertion type and significance instead of the condition/tumor name:
-
-```text
-<tier_label> - <assertion_type> - <clinical_significance> (<scv_count>)
-```
-
-Examples:
-
-- `Tier I - Strong - diagnostic - supports diagnosis (1)`
-- `Tier I - Strong - therapeutic - sensitivity/response (2)`
-- `Tier II - Potential - prognostic - poor outcome (1)`
-
-The condition/tumor name is not included in the classification label because it is already represented in the `objectCondition` field within the proposition.
+For somatic clinical impact (SCI) propositions, the classification label may include the tier, assertion type, and clinical significance.
 
 ---
 
 ## Proposition
 
-The `proposition` describes the condition-specific aggregate classification claim. It uses an SCV-matching proposition `type` and `predicate` (from `clinvar_proposition_types`) and carries an `objectCondition` containing just the condition.
+RCV propositions are stored in the `proposition` bundle section. Each RCV statement references its proposition via `#/proposition/{id}`.
 
-<div class="field-table" markdown>
+A resolved RCV proposition contains:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `type` | string | SCV-matching proposition type from `clinvar_proposition_types.gks_type` — e.g., `VariantPathogenicityProposition` |
-| `id` | string | Proposition ID — RCV accession without version, dash-separated (e.g., `RCV001781420-G-PATH-CP`) |
-| `subjectVariant` | string | Reference to the categorical variant — `clinvar:{variation_id}` |
-| `predicate` | string | SCV-matching predicate from `clinvar_proposition_types.gks_predicate` — e.g., `isCausalFor` |
-| `objectCondition` | object | The condition for this RCV, sourced from `gks_scv_condition_sets`. See [objectCondition](#objectcondition) |
+| `type` | string | Proposition type matching the underlying SCVs (e.g., `VariantPathogenicityProposition`) |
+| `id` | string | Proposition ID (e.g., `RCV001781420-G-PATH-CP`) |
+| `subjectVariant` | string | `#/variation/clinvar:{id}` reference |
+| `predicate` | string | Predicate matching the underlying SCVs (e.g., `isCausalFor`) |
+| `objectCondition` | string | `#/condition/clinvar.trait:{id}` or `#/conditionSet/clinvar.traitset:{id}` reference — the specific condition for this RCV |
 
-</div>
-
-### objectCondition
-
-`objectCondition` is the actual SCV condition, sourced from `gks_scv_condition_sets`. It may be either:
-
-- A full `Condition` MappableConcept (id, name, conceptType, primaryCoding, mappings) — for SCVs with a single condition
-- A full `ConditionSet` ConceptSet of conditions (id, conditions array, membershipOperator) — for SCVs with multiple conditions
-
-Extensions are excluded. The classification is **not** included in `objectCondition` — it lives on the statement-level `classification` field.
-
-Single condition example:
-
-```json
-{
-  "objectCondition": {
-    "conceptType": "Disease",
-    "id": "12345",
-    "name": "Hereditary breast and ovarian cancer syndrome",
-    "primaryCoding": {"code": "C0677776", "system": "MedGen"},
-    "mappings": [...]
-  }
-}
-```
-
-Multi-condition example (when the SCV uses a conditionSet):
-
-```json
-{
-  "objectCondition": {
-    "type": "ConceptSet",
-    "id": "tsid_999",
-    "conditions": [
-      {"conceptType": "Disease", "id": "1", "name": "Condition A", "primaryCoding": {...}},
-      {"conceptType": "Disease", "id": "2", "name": "Condition B", "primaryCoding": {...}}
-    ],
-    "membershipOperator": "AND"
-  }
-}
-```
-
-This structure is consistent across all aggregation steps — RCV uses the same condition-only form at every level regardless of submission level.
-
----
-
-## Extensions
-
-RCV statements carry the same extension as VCV:
-
-| Extension | Type | Description |
-| --- | --- | --- |
-| `clinvarReviewStatus` | string | The aggregate review status reflecting submission level and aggregation outcome |
+The key difference from VCV propositions: the `objectCondition` references the specific condition for this RCV accession, sourced from the representative SCV's condition mapping. VCV propositions may carry multiple condition references from contributing SCVs.
 
 ---
 
 ## Evidence Lines
 
-Evidence lines work identically to VCV — see [VCV Evidence Lines](vcv-statements.md#evidence-lines). At the top layer, evidence items contain fully inlined sub-statements. At the bottom layer (L1), evidence items are ID-only references to individual SCV submissions.
+Evidence lines work identically to VCV. Each evidence line references contributing or non-contributing submissions:
+
+```json
+{
+  "type": "EvidenceLine",
+  "directionOfEvidenceProvided": "supports",
+  "strengthOfEvidenceProvided": {
+    "conceptType": "Strength",
+    "name": "Contributing"
+  },
+  "evidenceItems": [
+    "#/scv/clinvar.submission:SCV001571657.2",
+    "#/scv/clinvar.submission:SCV000329383.7"
+  ]
+}
+```
+
+At the Classification layer, evidence items reference SCVs via `#/scv/`. At the Priority and Aggregate Contribution layers, evidence items reference lower-level RCV groupings via `#/rcv/`.
+
+See [VCV Evidence Lines](vcv-statements.md#evidence-lines) for the full field reference.
 
 ---
 
 ## Layer Hierarchy
 
-RCV statements use the same 2-layer aggregation hierarchy as VCV, with condition (`trait_set_id`) as an additional grouping dimension at every layer.
+RCV statements use the same multi-layer aggregation hierarchy as VCV, with condition (`trait_set_id`) as an additional grouping dimension at every layer.
 
 | Layer | ID Format | Aggregates By | Scope |
 | --- | --- | --- | --- |
-| Aggregate Contribution | `RCV001781420.1-G-PATH` | Proposition type | All |
-| Tier Grouping | `RCV006254391.1-S-SCI-CP` | Submission level | Somatic only |
-| Base Grouping | `RCV006254391.1-S-SCI-CP-TIER I - STRONG` | Submission level + tier | All |
+| Classification | `{RCV}.{ver}-{group}-{PROP}-{level}[-{TIER}]` | Classification label within submission level | All |
+| Priority | `{RCV}.{ver}-{group}-{PROP}-{level}` | Tier priority within submission level | Somatic only |
+| Aggregate Contribution | `{RCV}.{ver}-{group}-{PROP}` | Submission level (winner-takes-all) | All |
 
-Both germline and somatic RCV statements use the Aggregate Contribution Layer as the top level.
+Submission level ranking is `PG > EP > CP > NOCP > NOCL > FLAG`.
 
 See [RCV Procedures](../pipeline/rcv-statements/rcv-proc.md) for implementation details.
+
+---
+
+## Examples
+
+Annotated JSONC examples of RCV statement records are available in the repository:
+
+- [RCV statement examples](https://github.com/clingen-data-model/clinvar-gks/tree/main/examples/rcv)

--- a/docs/output-reference/scv-statements.md
+++ b/docs/output-reference/scv-statements.md
@@ -2,24 +2,11 @@
 
 ## Overview
 
-The SCV statement files contain one JSON record per ClinVar submitted clinical assertion (SCV). Each record is a VA-Spec `Statement` that captures a submitter's clinical interpretation of a variant — including the classification, evidence, condition, variant, and method.
+The `scv` bundle section contains one record per ClinVar submitted clinical assertion (SCV). Each record is a VA-Spec `Statement` that captures a submitter's clinical interpretation of a variant — including the classification, evidence, condition, variant, and method.
 
-Two formats are produced with identical content but different condition/variant embedding strategies:
+SCV statements use `#/` references to link to propositions, submitters, and conditions in their respective bundle sections rather than embedding full objects inline.
 
-- **`scv_by_ref.jsonl.gz`** — conditions and variants are referenced by ID with full structures available as separate records
-- **`scv_inline.jsonl.gz`** — conditions and variants are embedded inline within each statement record
-
-These files are produced by the [SCV Statements procedure](../pipeline/scv-statements/index.md).
-
----
-
-## By-Reference Format
-
-In the by-reference format, the `proposition.subjectVariant` field contains a string reference (JSON pointer) to the categorical variant record rather than the full embedded structure. This format is compact and avoids duplicating variant data across thousands of statements that reference the same variant.
-
-## Inline Format
-
-In the inline format, the `proposition.subjectVariant` field contains the full `CategoricalVariant` structure — the same content found in `variation.jsonl.gz` — embedded directly within each statement. Conditions are similarly embedded. This format is self-contained — each record has all the data needed to interpret the statement without cross-referencing other files.
+This section is produced by the [SCV Statements procedure](../pipeline/scv-statements/index.md).
 
 ---
 
@@ -33,54 +20,175 @@ Each record is a VA-Spec `Statement` with the following top-level fields:
 | --- | --- | --- |
 | `id` | string | SCV accession with version — `clinvar.submission:SCV000123456.1` |
 | `type` | string | Always `Statement` |
-| `classification` | object | The submitter's clinical classification (e.g., Pathogenic, Tier I) |
-| `direction` | string | Whether the evidence `supports` or `disputes` the proposition |
-| `strength` | object | Evidence strength (e.g., Strong, Supporting) — present for somatic/therapeutic statements |
-| `proposition` | object | The clinical claim — variant, condition, predicate, and qualifiers. See [Proposition](#proposition) |
-| `hasEvidenceLines` | array | Evidence lines linking to the proposition with outcome assessments |
-| `contributions` | array | Submitter and date information (submitted, created, evaluated) |
-| `reportedIn` | array | Supporting publications (PubMed references) |
-| `specifiedBy` | object | The classification method/guideline used |
+| `proposition` | string | `#/proposition/{id}` reference to the classification proposition |
+| `classification` | object | MappableConcept — the submitter's clinical classification. See [Classification](#classification) |
+| `strength` | object | MappableConcept — the evidence strength. See [Strength](#strength) |
+| `direction` | string | Whether the evidence `supports`, `disputes`, or is `neutral` toward the proposition |
+| `confidence` | string | Submission level label (e.g., `criteria provided`, `practice guideline`) |
 | `description` | string | Free-text interpretation summary (when provided by the submitter) |
-| `extensions` | array | ClinVar-specific metadata (SCV ID, version, review status, local key) |
+| `contributions` | array | Submitter and date information with `#/submitter/` references. See [Contributions](#contributions) |
+| `specifiedBy` | object | The classification method/guideline used |
+| `reportedIn` | array | Supporting publications (PubMed, DOI references) |
+| `extensions` | array | ClinVar-specific metadata. See [Extensions](#extensions) |
+| `hasEvidenceLines` | array | Evidence lines for somatic clinical impact assertions. See [Evidence Lines](#evidence-lines) |
 
 </div>
+
+---
+
+## Classification
+
+The `classification` field is a MappableConcept with the submitted clinical significance:
+
+```json
+{
+  "conceptType": "Classification",
+  "name": "Pathogenic",
+  "primaryCoding": {
+    "code": "pathogenic",
+    "system": "ACMG Guidelines, 2015"
+  },
+  "extensions": [
+    {
+      "name": "description",
+      "value": "for Hemochromatosis\nClassification is based on the criteria provided submission\nMay 2021 by Victorian Clinical Genetics Services"
+    }
+  ]
+}
+```
+
+The `primaryCoding` provides the machine-readable classification code and system from the `clinvar_clinsig_types` lookup table. The `extensions` array contains a human-readable description summarizing the condition, submission level, evaluation date, and submitter.
+
+---
+
+## Strength
+
+The `strength` field is a MappableConcept indicating the evidence strength:
+
+```json
+{
+  "conceptType": "Strength",
+  "name": "Definitive",
+  "primaryCoding": {
+    "code": "definitive",
+    "system": "ACMG Guidelines, 2015"
+  }
+}
+```
+
+The `primaryCoding` is present when the strength can be mapped to a specific code in the classification system.
+
+---
+
+## Contributions
+
+The `contributions` array records the submitter and key dates. Each contribution references the submitter via `#/submitter/`:
+
+```json
+[
+  {
+    "type": "Contribution",
+    "contributor": "#/submitter/clinvar.submitter:500104",
+    "date": "2022-12-24",
+    "activityType": "submitted"
+  },
+  {
+    "type": "Contribution",
+    "contributor": "#/submitter/clinvar.submitter:500104",
+    "date": "2022-12-24",
+    "activityType": "created"
+  },
+  {
+    "type": "Contribution",
+    "contributor": "#/submitter/clinvar.submitter:500104",
+    "date": "2021-05-06",
+    "activityType": "evaluated"
+  }
+]
+```
 
 ---
 
 ## Proposition
 
-The `proposition` describes the clinical claim being made. Its `type` determines the predicate and qualifier structure:
+SCV propositions are stored in the `proposition` bundle section, referenced by `#/proposition/{id}`. The proposition ID combines the SCV accession with an uppercase proposition type code:
 
-| Proposition Type | Predicate | Description |
-| --- | --- | --- |
-| `VariantPathogenicityProposition` | `isCausalFor` | Germline pathogenicity/benignity assertions |
-| `VariantClinicalSignificanceProposition` | `isClinicallySignificantFor` | Somatic clinical significance (AMP/ASCO/CAP tiering) |
-| `VariantOncogenicityProposition` | `isOncogenicFor` | Oncogenicity assertions |
-| `VariantTherapeuticResponseProposition` | `predictsSensitivityTo` | Therapeutic response predictions |
+```text
+SCV001234567-PATH
+```
 
-### Proposition Fields
-
-<div class="field-table" markdown>
+A resolved proposition contains:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `subjectVariant` | object or string | The variant — inline `CategoricalVariant` or a JSON pointer reference |
-| `objectCondition` | object | The disease or condition (for pathogenicity/oncogenicity) |
-| `objectTherapy` | object | The therapy (for therapeutic response propositions) |
-| `conditionQualifier` | object | The disease context (for therapeutic response propositions) |
-| `geneContextQualifier` | object | Gene context with NCBI Gene and HGNC identifiers |
-| `predicate` | string | The relationship asserted between variant and condition/therapy |
+| `id` | string | Proposition ID (e.g., `SCV001234567-PATH`) |
+| `type` | string | Proposition type (e.g., `VariantPathogenicityProposition`) |
+| `predicate` | string | The relationship asserted (e.g., `isCausalFor`) |
+| `subjectVariant` | string | `#/variation/clinvar:{id}` reference |
+| `objectCondition` | string | `#/condition/clinvar.trait:{id}` or `#/conditionSet/clinvar.traitset:{id}` reference |
+| `geneContextQualifier` | object | Gene context with NCBI Gene and HGNC identifiers (when applicable) |
+| `modeOfInheritanceQualifier` | object | Mode of inheritance with HPO coding (when submitted) |
+| `penetranceQualifier` | object | Penetrance qualifier (for low-penetrance/risk factor classifications) |
 
-</div>
+### Proposition Types
+
+| Proposition Type | Code | Predicate | Description |
+| --- | --- | --- | --- |
+| `VariantPathogenicityProposition` | `PATH` | `isCausalFor` | Germline pathogenicity/benignity |
+| `VariantOncogenicityProposition` | `ONCO` | `isOncogenicFor` | Oncogenicity |
+| `VariantClinicalSignificanceProposition` | `SCI` | `isClinicallySignificantFor` | Somatic clinical impact |
+| `ClinvarAssociationProposition` | `ASSOC` | `isAssociatedWith` | Association |
+| `ClinvarRiskFactorProposition` | `RF` | `isRiskFactorFor` | Risk factor |
+| `ClinvarDrugResponseProposition` | `DR` | `hasDrugResponseFor` | Drug response |
+| `ClinvarProtectiveProposition` | `PROT` | `isProtectiveFor` | Protective |
+| `ClinvarAffectsProposition` | `AFF` | `hasAffectFor` | Affects |
+| `ClinvarConfersSensitivityProposition` | `SENS` | `confersSensitivityFor` | Confers sensitivity |
+| `ClinvarOtherProposition` | `OTH` | `isClinvarOtherAssociationFor` | Other |
+| `ClinvarNotProvidedProposition` | `NP` | `hasNoProvidedClassificationFor` | Not provided |
+| `ClinvarConflictingDataFromSubmitterProposition` | `CONF` | `isConflictingDataFromSubmittersFor` | Conflicting data |
+
+For somatic clinical impact, target propositions (evidence line propositions) use these codes: `PROG` (Prognostic), `DIAG` (Diagnostic), `TR` (Therapeutic Response).
+
+See [Propositions](../profiles/propositions.md) for the full profile documentation.
 
 ---
 
-## Statement Types
+## Evidence Lines
 
-For the full mapping between ClinVar assertion types and GKS statement/proposition types, see [Statement Types](../profiles/statement-types.md).
+Evidence lines appear on somatic clinical impact (SCI) statements. Each evidence line carries a target proposition, direction, outcome, and condition extensions:
 
-For classification value mappings, see [Classifications](../profiles/classifications.md).
+```json
+{
+  "type": "EvidenceLine",
+  "proposition": "#/proposition/SCV004565358-TR",
+  "directionOfEvidenceProvided": "supports",
+  "evidenceOutcome": {
+    "conceptType": "Outcome",
+    "name": "tier 1"
+  },
+  "extensions": [ ... ]
+}
+```
+
+The `evidenceOutcome` is a MappableConcept with `conceptType: "Outcome"` indicating the tier classification for the target proposition.
+
+---
+
+## Extensions
+
+The `extensions` array carries ClinVar-specific metadata:
+
+| Extension Name | Value Type | Description |
+| --- | --- | --- |
+| `clinvarScvId` | string | SCV accession without version (e.g., `SCV002769510`) |
+| `clinvarScvVersion` | string | SCV version number |
+| `submittedCondition` / `submittedConditionSet` | object | Submitted condition provenance with normalization details, trait mapping, and `#/condition/` references |
+| `clinvarScvReviewStatus` | string | ClinVar review status (e.g., `criteria provided, single submitter`) |
+| `submittedScvClassification` | string | Original submitted classification (when it differs from the normalized label) |
+| `submittedScvLocalKey` | string | Submitter's local key for the record |
+| `submissionLevel` | string | Submission level code (e.g., `CP`, `EP`, `PG`) |
+
+See [SCV Extensions](../pipeline/scv-statements/scv-extensions.md) for the complete extension reference.
 
 ---
 

--- a/docs/output-reference/vcv-statements.md
+++ b/docs/output-reference/vcv-statements.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-The VCV statement output contains one JSON record per variant-level aggregate classification. Each record is a `Statement` that aggregates individual SCV submissions into a hierarchical summary — combining classifications across conditions and submission levels to produce a single variant-level result.
+The `vcv` bundle section contains one record per variation-level aggregate classification. Each record is a `Statement` that aggregates individual SCV submissions into a hierarchical summary — combining classifications across submission levels to produce a single variation-level result.
 
-VCV statements are produced by the [VCV Procedures](../pipeline/vcv-statements/vcv-proc.md) and serialized via the [JSON proc](../pipeline/scv-statements/index.md). The output table is `gks_vcv_statement`.
+VCV statements use `#/` references for propositions, contributing SCVs, and lower-level VCV groupings. They are produced by the [VCV Procedures](../pipeline/vcv-statements/vcv-proc.md).
 
 ---
 
@@ -16,15 +16,15 @@ Each record is a `Statement` with the following top-level fields:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `id` | string | VCV accession with version and aggregation path — e.g., `VCV000012582.63-G` |
+| `id` | string | VCV layer ID — e.g., `VCV000012582.63-G-PATH-CP` |
 | `type` | string | Always `Statement` |
-| `confidence` | string | The submission level label (e.g., `"expert panel"`, `"assertion criteria provided"`) |
-| `direction` | string | Derived from the aggregate classification label; passed through from the contributing SCV for single-SCV aggregations |
-| `strength` | string | Derived from the aggregate classification label; passed through from the contributing SCV for single-SCV aggregations |
-| `classification` | object | Aggregate classification label. See [Classification](#classification) |
-| `proposition` | object | The aggregate proposition with variant, objectCondition, and SCV-matching type/predicate. See [Proposition](#proposition) |
-| `extensions` | array | Aggregate metadata — `clinvarReviewStatus`. See [Extensions](#extensions) |
-| `evidenceLines` | array | Contributing and non-contributing evidence from lower aggregation layers. See [Evidence Lines](#evidence-lines) |
+| `proposition` | string | `#/proposition/{id}` reference to the aggregate proposition |
+| `classification` | object | MappableConcept — the aggregate classification label. See [Classification](#classification) |
+| `strength` | object | MappableConcept — the aggregate evidence strength. See [Strength](#strength) |
+| `direction` | string | `supports`, `disputes`, or `neutral` — derived from the aggregate classification |
+| `confidence` | string | Submission level label (e.g., `criteria provided`, `expert panel`) |
+| `extensions` | array | Aggregate metadata — `clinvarReviewStatus` |
+| `evidenceLines` | array | Contributing and non-contributing evidence. See [Evidence Lines](#evidence-lines) |
 
 </div>
 
@@ -32,88 +32,110 @@ Each record is a `Statement` with the following top-level fields:
 
 ## Classification
 
-All VCV statements use a single `classification` attribute for the aggregate classification.
-
-### classification
-
-Used by all submission levels (PG, EP, CP, NOCP, NOCL, FLAG). Contains a single aggregate label with an optional `conflictingExplanation` extension when the classification is conflicting.
+The `classification` field is a MappableConcept with the aggregate classification label:
 
 ```json
 {
-  "classification": {
-    "conceptType": "Classification",
-    "name": "Pathogenic/Likely pathogenic",
-    "extension": [
-      {"name": "conflictingExplanation", "value": "Pathogenic(3); Likely pathogenic(2)"}
-    ]
-  }
+  "conceptType": "Classification",
+  "name": "Pathogenic/Likely pathogenic",
+  "extensions": [
+    {"name": "conflictingExplanation", "value": "Pathogenic(3); Likely pathogenic(2)"}
+  ]
 }
 ```
+
+The `extensions` array includes a `conflictingExplanation` when multiple contributing submissions have different clinical significance values. This extension is only present for CP-level aggregations with conflicts.
+
+---
+
+## Strength
+
+The `strength` field is a MappableConcept derived from the aggregate classification:
+
+```json
+{
+  "conceptType": "Strength",
+  "name": "Definitive"
+}
+```
+
+| Classification | Strength |
+| --- | --- |
+| Pathogenic, Benign, Oncogenic | Definitive |
+| Likely pathogenic, Likely benign, Likely Oncogenic | Likely |
+| Tier I (strong clinical significance) | Strong |
+| Tier II (potential clinical significance) | Potential |
+| Tier IV (benign/likely benign) | Likely |
+| Uncertain, Conflicting, Tier III | *null (omitted)* |
+
+For single-SCV aggregations, the strength is passed through from the contributing SCV.
 
 ---
 
 ## Proposition
 
-The `proposition` describes the aggregate classification claim. It uses an SCV-matching proposition `type` and `predicate` (from `clinvar_proposition_types`) and carries an `objectCondition` representing the unique conditions from contributing SCVs.
+VCV propositions are stored in the `proposition` bundle section. Each VCV statement references its proposition via `#/proposition/{id}`.
 
-<div class="field-table" markdown>
+A resolved VCV proposition contains:
 
 | Field | Type | Description |
 | --- | --- | --- |
-| `type` | string | SCV-matching proposition type from `clinvar_proposition_types.gks_type` — e.g., `VariantPathogenicityProposition` |
-| `id` | string | Proposition ID — VCV accession without version, dash-separated (e.g., `VCV000012582-G-PATH-CP`) |
-| `subjectVariant` | string | Reference to the categorical variant — `clinvar:{variation_id}` |
-| `predicate` | string | SCV-matching predicate from `clinvar_proposition_types.gks_predicate` — e.g., `isCausalFor` |
-| `objectCondition` | object | The unique conditions from contributing SCVs — a single MappableConcept when there is one condition, or an OR ConceptSet when there are multiple distinct conditions |
-
-</div>
-
-!!! note
-    PG and EP are separate submission levels; PG outranks EP at the Aggregate Contribution Layer winner-takes-all.
-
----
-
-## Extensions
-
-VCV statements carry a single extension:
-
-| Extension | Type | Description |
-| --- | --- | --- |
-| `clinvarReviewStatus` | string | The aggregate review status reflecting submission level and aggregation outcome. See [Aggregate Review Status](../pipeline/vcv-statements/vcv-aggregation-rules.md#aggregate-review-status) for the complete value table |
+| `type` | string | Proposition type matching the underlying SCVs (e.g., `VariantPathogenicityProposition`) |
+| `id` | string | Proposition ID (e.g., `VCV000012582-G-PATH-CP`) |
+| `subjectVariant` | string | `#/variation/clinvar:{id}` reference |
+| `predicate` | string | Predicate matching the underlying SCVs (e.g., `isCausalFor`) |
+| `objectCondition` | array | Unique condition references from contributing SCVs (`#/condition/` and/or `#/conditionSet/`) |
 
 ---
 
 ## Evidence Lines
 
-Each VCV statement contains `evidenceLines` — an array of evidence line objects that reference the aggregation layer below:
+Each VCV statement contains `evidenceLines` — an array of evidence line objects that reference contributing and non-contributing submissions:
+
+```json
+{
+  "type": "EvidenceLine",
+  "directionOfEvidenceProvided": "supports",
+  "strengthOfEvidenceProvided": {
+    "conceptType": "Strength",
+    "name": "Contributing"
+  },
+  "evidenceItems": [
+    "#/scv/clinvar.submission:SCV001571657.2",
+    "#/scv/clinvar.submission:SCV000329383.7"
+  ]
+}
+```
 
 | Field | Type | Description |
 | --- | --- | --- |
 | `type` | string | Always `EvidenceLine` |
-| `directionOfEvidenceProvided` | string | Always `supports` |
-| `strengthOfEvidenceProvided` | string | `contributing` or `non-contributing` — indicates whether this evidence contributed to the aggregate classification |
-| `evidenceItems` | array | Array of referenced statements from the layer below — either full inlined sub-statements or leaf-level SCV ID references |
+| `directionOfEvidenceProvided` | string | `supports` or `neutral` |
+| `strengthOfEvidenceProvided` | object | MappableConcept — `Contributing` or `Non-contributing` |
+| `evidenceItems` | array | `#/scv/` references (at classification layer) or `#/vcv/` references (at priority/aggregate layers) |
 
-At the top layer (the Aggregate Contribution Layer for both germline and somatic), evidence items contain fully inlined sub-statements with their own classification, proposition, extensions, and nested evidence lines. At the bottom layer (Base Grouping), evidence items are ID-only references to individual SCV submissions:
-
-```json
-{"id": "clinvar.submission:SCV001571657.2"}
-```
-
-These references resolve to full SCV records in `scv_by_ref.jsonl.gz`. See [ID References](id-references.md) for resolution details.
+Contributing evidence lines use `directionOfEvidenceProvided: "supports"`. Non-contributing evidence lines (lower-ranked submission levels) use `directionOfEvidenceProvided: "neutral"`.
 
 ---
 
 ## Layer Hierarchy
 
-VCV statements are built through a 2-layer aggregation hierarchy. The top-level record is the outermost layer; each nested evidence item is one layer deeper.
+VCV statements are built through a multi-layer aggregation hierarchy. The top-level output is the Aggregate Contribution layer; lower layers appear in the `evidenceItems` of higher layers.
 
 | Layer | ID Format | Aggregates By | Scope |
 | --- | --- | --- | --- |
-| Aggregate Contribution | `VCV000012582.63-G-PATH` | Proposition type | All |
-| Tier Grouping | `VCV000012582.63-G-SCI-CP` | Submission level | Somatic only |
-| Base Grouping | `VCV000012582.63-G-SCI-CP-PATHOGENIC` | Submission level + tier | All |
+| Classification | `{VCV}.{ver}-{group}-{PROP}-{level}[-{TIER}]` | Classification label within submission level | All |
+| Priority | `{VCV}.{ver}-{group}-{PROP}-{level}` | Tier priority within submission level | Somatic only |
+| Aggregate Contribution | `{VCV}.{ver}-{group}-{PROP}` | Submission level (winner-takes-all) | All |
 
-Both germline and somatic VCV statements use the Aggregate Contribution Layer as the top level. Tier Grouping tier components are uppercase (e.g., `PATHOGENIC`). Submission level ranking at the Aggregate Contribution Layer is `PG > EP > CP > NOCP > NOCL > FLAG`, with only matching submission levels aggregating together at Base Grouping.
+Submission level ranking at the Aggregate Contribution layer is `PG > EP > CP > NOCP > NOCL > FLAG`, with only matching submission levels aggregating together at the Classification layer.
 
 See [Aggregation Rules](../pipeline/vcv-statements/vcv-aggregation-rules.md) for detailed submission level logic and [VCV Procedures](../pipeline/vcv-statements/vcv-proc.md) for implementation details.
+
+---
+
+## Examples
+
+Annotated JSONC examples of VCV statement records are available in the repository:
+
+- [VCV statement examples](https://github.com/clingen-data-model/clinvar-gks/tree/main/examples/vcv)

--- a/docs/profiles/propositions.md
+++ b/docs/profiles/propositions.md
@@ -31,3 +31,13 @@ These custom propositions are defined specifically for the ClinVar-GKS dataset t
 ## Aggregate Propositions
 
 Aggregate (VCV and RCV) statements use the same proposition types and predicates as their underlying SCV submissions. For example, a VCV pathogenicity aggregate uses `VariantPathogenicityProposition` with `isCausalFor`, matching the SCVs it aggregates.
+
+!!! info "Design Consideration: Proposition Normalization"
+
+    In the current v1 release, each SCV statement generates its own proposition instance keyed by `{scv_id}-{PROP_CODE}`. This means two SCVs asserting the exact same subject-predicate-object relationship (e.g., variant X `isCausalFor` condition Y) produce two separate proposition entries in the bundle, even though they represent the same logical assertion.
+
+    A future improvement may normalize propositions so that identical subject-predicate-object combinations are represented as a single shared instance — treating propositions as **value objects** in their own right. Since the proposition is the fundamental component for identifying which statements can be meaningfully compared, honoring that identity in the dataset would allow consumers to directly group and compare all statements that share the same proposition without field-by-field comparison.
+
+    This would require a content-addressable identifier scheme for propositions (e.g., hashing the subject + predicate + object) so that SCV statements can reference a shared proposition by its computed key.
+
+    At the aggregate VCV and RCV level, proposition sharing is less impactful — aggregate propositions build on the shared SCV propositions and further qualify them with review status, submission level, and other aggregation-specific attributes that make exact duplication less common. However, evidence lines within VCV/RCV statements could also benefit from referencing shared propositions rather than embedding layer-specific copies.

--- a/docs/profiles/review-status.md
+++ b/docs/profiles/review-status.md
@@ -26,14 +26,18 @@ RCVs and VCVs use only the highest-ranking review status levels in the aggregate
 
 The rank order is a quantification of the review status levels used to appropriately segregate submissions within a single statement type, variant, and condition. Rank order is not a ClinVar concept but is used during the ClinVar-GKS aggregation process.
 
-| Rank | Review Status | Stars |
-| --- | --- | --- |
-| 4 | practice guideline | 4 |
-| 3 | reviewed by expert panel | 3 |
-| 1 | criteria provided, single submitter | 1 |
-| 0 | no assertion criteria provided | 0 |
-| -1 | no classification provided | 0 |
-| -3 | flagged submission | 0 |
+| Rank | Review Status | Stars | Scope |
+| --- | --- | --- | --- |
+| 4 | practice guideline | 4 | Individual / Aggregate |
+| 3 | reviewed by expert panel | 3 | Individual / Aggregate |
+| 2 | criteria provided, multiple submitters, no conflicts | 2 | Aggregate only |
+| 2 | criteria provided, conflicting classifications | 1 | Aggregate only |
+| 1 | criteria provided, single submitter | 1 | Individual / Aggregate |
+| 0 | no assertion criteria provided | 0 | Individual / Aggregate |
+| -1 | no classification provided | 0 | Individual / Aggregate |
+| -3 | flagged submission | 0 | Individual / Aggregate |
+
+Rank 2 statuses only appear on aggregate (VCV/RCV) statements where multiple CP-level submissions exist. A single CP submission produces rank 1. The distinction between "no conflicts" and "conflicting classifications" at rank 2 reflects whether the contributing CP submissions agree on clinical significance.
 
 ## Aggregate Review Status
 

--- a/docs/profiles/review-status.md
+++ b/docs/profiles/review-status.md
@@ -31,7 +31,7 @@ The rank order is a quantification of the review status levels used to appropria
 | 4 | practice guideline | 4 | Individual / Aggregate |
 | 3 | reviewed by expert panel | 3 | Individual / Aggregate |
 | 2 | criteria provided, multiple submitters, no conflicts | 2 | Aggregate only |
-| 2 | criteria provided, conflicting classifications | 1 | Aggregate only |
+| 1 | criteria provided, conflicting classifications | 1 | Aggregate only |
 | 1 | criteria provided, single submitter | 1 | Individual / Aggregate |
 | 0 | no assertion criteria provided | 0 | Individual / Aggregate |
 | -1 | no classification provided | 0 | Individual / Aggregate |

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -211,39 +211,39 @@ Key terms, acronyms, and concepts used throughout the ClinVar-GKS documentation.
 ## Identifier Formats
 
 **clinvar:{variation_id}**
-:   ClinVar variation identifier. References a CategoricalVariant record in `variation.jsonl.gz`. Example: `clinvar:12582`.
+:   ClinVar variation identifier. References a CategoricalVariant record in the `variation` bundle section. Example: `clinvar:12582`.
 
 **clinvar.submission:SCV{id}.{version}**
-:   SCV submission identifier with version. References an SCV Statement record. Example: `clinvar.submission:SCV001571657.2`.
+:   SCV submission identifier with version. References an SCV Statement record in the `scv` bundle section. Example: `clinvar.submission:SCV001571657.2`.
 
 **clinvar.submitter:{submitter_id}**
-:   Submitter organization identifier. Embedded in SCV records. Example: `clinvar.submitter:508027`.
+:   Submitter organization identifier. References a submitter record in the `submitter` bundle section. Example: `clinvar.submitter:508027`.
+
+**clinvar.trait:{trait_id}**
+:   Condition/trait identifier. References a condition record in the `condition` bundle section. Example: `clinvar.trait:9580`.
+
+**clinvar.traitset:{trait_set_id}**
+:   Condition set identifier. References a condition set in the `conditionSet` bundle section. Example: `clinvar.traitset:1234`.
 
 **ga4gh:{type}.{digest}**
-:   VRS identity digest. Embedded within CategoricalVariant constraints. Example: `ga4gh:VA.xXBYkzzu1AH0oyMKlbBtP2`.
+:   VRS identity digest. References alleles or locations in the corresponding bundle sections. Example: `ga4gh:VA.xXBYkzzu1AH0oyMKlbBtP2`.
 
 ---
 
-## Output Files
+## Output Format
 
-**variation.jsonl.gz**
-:   Output file containing CategoricalVariant records. One record per ClinVar variation with a resolved VRS identity.
+**Bundle**
+:   A single JSON file containing all data for a ClinVar release, organized as named sections at the root level. Each section is a keyed collection of objects of the same class, where the key is the object's unique identifier. Objects reference each other using `#/` JSON pointer strings.
 
-**scv_by_ref.jsonl.gz**
-:   Output file containing SCV statements with variants referenced by ID. Compact format.
+**Bundle Section**
+:   A named top-level key in the bundle file (e.g., `variation`, `scv`, `proposition`) containing a keyed collection of objects.
 
-**scv_inline.jsonl.gz**
-:   Output file containing SCV statements with full variant objects embedded inline. Self-contained format.
-
-**vcv.jsonl.gz**
-:   Output file containing VCV aggregate classification statements with hierarchical evidence structure.
+**JSON Pointer Reference**
+:   A `#/{section}/{key}` string used to reference an object in another bundle section. Example: `#/allele/ga4gh:VA.abc123` resolves to the allele with that key in the `allele` section.
 
 ---
 
 ## Technical Terms
-
-**JSONL**
-:   Newline-delimited JSON format. One complete JSON object per line, no surrounding array. Used for all ClinVar-GKS output files.
 
 **Null Stripping**
 :   Technique where null-valued fields and empty arrays are omitted from JSON output via `JSON_STRIP_NULLS(remove_empty => TRUE)`.

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -65,12 +65,26 @@
 }
 
 /* Reduce space between header and tabs navigation */
-.md-header {
-  padding: 0;
+.md-header__inner {
+  padding-top: 0;
+  padding-bottom: 0;
+  min-height: 2rem;
+}
+
+.md-header__topic {
+  margin: 0;
 }
 
 .md-tabs {
   padding: 0;
+  margin: 0;
+  line-height: 1.6;
+}
+
+.md-tabs__link {
+  padding-top: 0.2rem;
+  padding-bottom: 0.2rem;
+  margin-top: 0;
 }
 
 /* Header logos — fill available height with minimal padding */

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -64,42 +64,15 @@
   width: 1px;
 }
 
-/* Compact header and tabs navigation */
-.md-header {
-  box-shadow: none;
-}
-
-.md-header__inner {
-  padding-top: 0.1rem;
-  padding-bottom: 0.1rem;
-  min-height: 0;
-  height: 2.2rem;
-}
-
-.md-header__topic {
-  margin: 0;
-}
-
-.md-header__button.md-logo {
-  padding: 0.1rem 0;
-}
-
+/* Remove padding below tabs navigation */
 .md-tabs {
-  padding: 0;
-  margin: 0;
-  line-height: 1;
-}
-
-.md-tabs__link {
-  padding-top: 0.3rem;
-  padding-bottom: 0.3rem;
-  margin-top: 0;
-  font-size: 0.72rem;
+  margin-bottom: 0;
+  padding-bottom: 0;
 }
 
 /* Header logos — fill available height with minimal padding */
 .md-header__button.md-logo img {
-  height: 28px;
+  height: 40px;
 }
 
 .md-header__ga4gh {
@@ -111,7 +84,7 @@
 }
 
 .md-header__ga4gh img {
-  height: 28px;
+  height: 40px;
   width: auto;
   filter: brightness(0) invert(1);
 }

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -64,6 +64,15 @@
   width: 1px;
 }
 
+/* Reduce space between header and tabs navigation */
+.md-header {
+  padding: 0;
+}
+
+.md-tabs {
+  padding: 0;
+}
+
 /* Header logos — fill available height with minimal padding */
 .md-header__button.md-logo img {
   height: 40px;

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -64,32 +64,42 @@
   width: 1px;
 }
 
-/* Reduce space between header and tabs navigation */
+/* Compact header and tabs navigation */
+.md-header {
+  box-shadow: none;
+}
+
 .md-header__inner {
-  padding-top: 0;
-  padding-bottom: 0;
-  min-height: 2rem;
+  padding-top: 0.1rem;
+  padding-bottom: 0.1rem;
+  min-height: 0;
+  height: 2.2rem;
 }
 
 .md-header__topic {
   margin: 0;
 }
 
+.md-header__button.md-logo {
+  padding: 0.1rem 0;
+}
+
 .md-tabs {
   padding: 0;
   margin: 0;
-  line-height: 1.6;
+  line-height: 1;
 }
 
 .md-tabs__link {
-  padding-top: 0.2rem;
-  padding-bottom: 0.2rem;
+  padding-top: 0.3rem;
+  padding-bottom: 0.3rem;
   margin-top: 0;
+  font-size: 0.72rem;
 }
 
 /* Header logos — fill available height with minimal padding */
 .md-header__button.md-logo img {
-  height: 40px;
+  height: 28px;
 }
 
 .md-header__ga4gh {
@@ -101,7 +111,7 @@
 }
 
 .md-header__ga4gh img {
-  height: 40px;
+  height: 28px;
   width: auto;
   filter: brightness(0) invert(1);
 }

--- a/docs/superpowers/plans/2026-04-14-aggregation-layer-refactor.md
+++ b/docs/superpowers/plans/2026-04-14-aggregation-layer-refactor.md
@@ -1,0 +1,707 @@
+# Aggregation Layer Refactor Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove Layer 4 (group aggregator) from VCV/RCV pipelines, rebrand the remaining layers as a two-layer conceptual model: "Grouping Layer" (L1+L2) and "Aggregate Contribution Layer" (L3).
+
+**Architecture:** The current 4-layer hierarchy (L1 Base → L2 Tier → L3 Submission Level → L4 Group) becomes a 2-conceptual-layer model. L1 and L2 are unified under "Grouping Layer" (separate SQL steps, single conceptual layer). L3 becomes the "Aggregate Contribution Layer" — the terminal layer for both germline and somatic. L4 is deleted entirely. Germline variants with multiple proposition types will now produce separate final statements per proposition type instead of one combined statement.
+
+**Tech Stack:** BigQuery SQL stored procedures, MkDocs documentation (Markdown), JSONC example files
+
+---
+
+## Summary of Changes
+
+### What's Removed
+- **Layer 4 aggregation** (`gks_vcv_layer4_group_agg`, `gks_rcv_layer4_group_agg`) — the germline-only cross-proposition-type aggregation is eliminated
+- **Layer 4 statement generation** (BASE + PRE) in both VCV and RCV statement procs
+- The FINAL union changes from "germline L4 + somatic L3" to just "all L3" (no filtering needed)
+
+### What's Renamed
+| Old Name | New Conceptual Name | Table Name Change |
+|----------|-------------------|-------------------|
+| Layer 1 (Base Aggregator) | Grouping Layer — Base Grouping | `gks_{x}cv_layer1_base_agg` → `gks_{x}cv_grouping_base_agg` |
+| Layer 2 (Tier Aggregator) | Grouping Layer — Tier Grouping | `gks_{x}cv_layer2_tier_agg` → `gks_{x}cv_grouping_tier_agg` |
+| Layer 3 (Submission Level Aggregator) | Aggregate Contribution Layer | `gks_{x}cv_layer3_prop_agg` → `gks_{x}cv_aggregate_contribution` |
+
+### Behavioral Changes
+- **Germline output**: Instead of one VCV/RCV statement per `(variation, statement_group)` combining all prop types, there will be one statement per `(variation, statement_group, prop_type)` — e.g., `VCV000012582.63-G-PATH`, `VCV000012582.63-G-ASSOC`, `VCV000012582.63-G-NP` as separate final statements
+- **Somatic output**: No change — somatic already terminated at L3
+- **JSON nesting depth**: Drops from 4 levels to 3 levels for germline statements
+- **Statement IDs**: The shortest ID format changes from `VCV.ver-G` (L4) to `VCV.ver-G-PROP` (new terminal). No more IDs without a proposition type component
+- **Proposition aggregateQualifiers**: The terminal layer now always has `[AssertionGroup, PropositionType]` instead of just `[AssertionGroup]`
+
+---
+
+## Files Affected
+
+### SQL Procedures (core implementation)
+| File | Changes |
+|------|---------|
+| `src/procedures/gks-vcv-proc.sql` | Remove L4 block, rename L1/L2/L3 variables and table names, update comments |
+| `src/procedures/gks-vcv-statement-proc.sql` | Remove L4 BASE+PRE blocks, rename L1/L2/L3 variables and table names, simplify FINAL union, update cleanup |
+| `src/procedures/gks-rcv-proc.sql` | Remove L4 block, rename L1/L2/L3 variables and table names, update comments |
+| `src/procedures/gks-rcv-statement-proc.sql` | Remove L4 BASE+PRE blocks, rename L1/L2/L3 variables and table names, simplify FINAL union, update cleanup |
+
+### Documentation
+| File | Changes |
+|------|---------|
+| `docs/pipeline/vcv-statements/vcv-aggregation-rules.md` | Rewrite Layer Hierarchy section with new 2-layer model |
+| `docs/pipeline/vcv-statements/vcv-proc.md` | Remove L4 steps, rename all layer references, update output tables |
+| `docs/pipeline/vcv-statements/index.md` | Update pipeline flow diagram and key concepts |
+| `docs/pipeline/rcv-statements/rcv-proc.md` | Remove L4 steps, rename all layer references, update output tables |
+| `docs/pipeline/rcv-statements/index.md` | Update pipeline flow diagram and key concepts |
+| `docs/reference/glossary.md` | Update VCV Aggregation section with new layer names |
+| `docs/data-access/examples.md` | Update VCV examples table (descriptions reference layer counts) |
+| `docs/output-reference/vcv-statements.md` | Rewrite Layer Hierarchy section, remove L4, update all layer references |
+| `docs/output-reference/rcv-statements.md` | Rewrite Layer Hierarchy section, remove L4, update all layer references |
+| `docs/pipeline/vcv-statements/vcv-extensions.md` | Rename "Layer 1" reference to "Base Grouping" |
+| `docs/pipeline/rcv-statements/rcv-extensions.md` | Rename "Layer 1" and "four layers" references to new naming |
+
+### Example Files
+| File | Changes |
+|------|---------|
+| `examples/vcv/VCV000012582.63-G.jsonc` | **Rename to `VCV000012582.63-G-PATH.jsonc`** and replace with Aggregate Contribution terminal format |
+| `examples/vcv/VCV-PG-example.jsonc` | Update layer comments |
+| `examples/vcv/VCV-EP-example.jsonc` | Update layer comments |
+| `examples/rcv/RCV001781420.1-G-PATH.jsonc` | **Replace entirely** with Aggregate Contribution layer terminal format |
+| `examples/rcv/RCV006254391.1-S-SCI.jsonc` | Update layer comments |
+
+---
+
+## Chunk 1: VCV Aggregation Procedure
+
+### Task 1: Remove Layer 4 from gks-vcv-proc.sql
+
+**Files:**
+- Modify: `src/procedures/gks-vcv-proc.sql`
+
+- [ ] **Step 1: Remove Layer 4 DECLARE and the Layer 4 SQL block**
+
+Remove the `DECLARE query_layer4 STRING;` declaration (line 7) and the entire Layer 4 block (lines 283-331: from `-- LAYER 4: FINAL GROUP AGGREGATOR` through `EXECUTE IMMEDIATE query_layer4;`).
+
+- [ ] **Step 2: Rename Layer 1-3 variables and table names**
+
+Rename throughout the file:
+- `query_layer1` → `query_grouping_base`
+- `query_layer2` → `query_grouping_tier`
+- `query_layer3` → `query_agg_contribution`
+- `gks_vcv_layer1_base_agg` → `gks_vcv_grouping_base_agg`
+- `gks_vcv_layer2_tier_agg` → `gks_vcv_grouping_tier_agg`
+- `gks_vcv_layer3_prop_agg` → `gks_vcv_aggregate_contribution`
+
+- [ ] **Step 3: Update SQL comments**
+
+Replace the section comment headers:
+- `LAYER 1: MATERIALIZE BASE DATA` → `GROUPING LAYER: MATERIALIZE BASE DATA`
+- `LAYER 1: BASE AGGREGATION` → `GROUPING LAYER: BASE GROUPING`
+- `LAYER 2: TIER AGGREGATOR` → `GROUPING LAYER: TIER GROUPING (Somatic only)`
+- `LAYER 3: SUBMISSION LEVEL AGGREGATOR` → `AGGREGATE CONTRIBUTION LAYER`
+
+References to Layer 1/Layer 2 within the Aggregate Contribution Layer SQL (the `unified_input` CTE that unions L2 and L1) should reference the new table names only — the SQL logic itself doesn't change.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/procedures/gks-vcv-proc.sql
+git commit -m "Remove Layer 4 and rename layers in gks_vcv_proc"
+```
+
+---
+
+### Task 2: Remove Layer 4 from gks-vcv-statement-proc.sql
+
+**Files:**
+- Modify: `src/procedures/gks-vcv-statement-proc.sql`
+
+- [ ] **Step 1: Remove Layer 4 DECLARE variables**
+
+Remove:
+- `DECLARE query_layer4 STRING;` (line 6)
+- `DECLARE query_l4_pre STRING;` (line 10)
+
+- [ ] **Step 2: Remove Layer 4 from cleanup_temp_tables call**
+
+Remove `'temp_vcv_layer4_statements'` and `'temp_vcv_layer4_pre'` from the cleanup array (lines 27-30).
+
+- [ ] **Step 3: Remove Layer 4 BASE block**
+
+Delete the entire Layer 4 BASE section (lines 254-325: from `-- LAYER 4: FINAL GROUP AGGREGATOR` through `EXECUTE IMMEDIATE query_layer4;`).
+
+- [ ] **Step 4: Remove Layer 4 PRE block**
+
+Delete the entire Layer 4 PRE section (lines 478-531: from `-- LAYER 4 PRE:` through `EXECUTE IMMEDIATE query_l4_pre;`).
+
+- [ ] **Step 5: Simplify the FINAL union**
+
+Replace the FINAL block. The old logic was:
+```sql
+SELECT * FROM temp_vcv_layer4_pre
+UNION ALL
+SELECT * FROM temp_vcv_layer3_pre WHERE id LIKE '%-S-%'
+```
+
+The new logic is simply:
+```sql
+SELECT * FROM {P}.temp_vcv_agg_contribution_pre
+```
+
+No UNION needed — the Aggregate Contribution Layer is now terminal for both germline and somatic.
+
+- [ ] **Step 6: Remove Layer 4 DROP TABLE statements**
+
+Remove:
+- `DROP TABLE _SESSION.temp_vcv_layer4_statements;`
+- `DROP TABLE _SESSION.temp_vcv_layer4_pre;`
+
+- [ ] **Step 7: Rename all Layer 1-3 variables and table references**
+
+Rename throughout the file:
+- `query_layer1` → `query_grouping_base`
+- `query_layer2` → `query_grouping_tier`
+- `query_layer3` → `query_agg_contribution`
+- `query_l1_pre` → `query_grouping_base_pre`
+- `query_l2_pre` → `query_grouping_tier_pre`
+- `query_l3_pre` → `query_agg_contribution_pre`
+- `temp_vcv_layer1_statements` → `temp_vcv_grouping_base_statements`
+- `temp_vcv_layer2_statements` → `temp_vcv_grouping_tier_statements`
+- `temp_vcv_layer3_statements` → `temp_vcv_agg_contribution_statements`
+- `temp_vcv_layer1_pre` → `temp_vcv_grouping_base_pre`
+- `temp_vcv_layer2_pre` → `temp_vcv_grouping_tier_pre`
+- `temp_vcv_layer3_pre` → `temp_vcv_agg_contribution_pre`
+- `gks_vcv_layer1_base_agg` → `gks_vcv_grouping_base_agg`
+- `gks_vcv_layer2_tier_agg` → `gks_vcv_grouping_tier_agg`
+- `gks_vcv_layer3_prop_agg` → `gks_vcv_aggregate_contribution`
+
+- [ ] **Step 8: Update SQL comment headers**
+
+Replace section comments to match the new naming convention (same pattern as Task 1 Step 3), plus:
+- `LAYER 1 PRE:` → `GROUPING BASE PRE:`
+- `LAYER 2 PRE:` → `GROUPING TIER PRE:`
+- `LAYER 3 PRE:` → `AGGREGATE CONTRIBUTION PRE:`
+- `FINAL: Combined VCV statement pre (germline L4 + somatic L3)` → `FINAL: VCV statement pre (all Aggregate Contribution statements)`
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/procedures/gks-vcv-statement-proc.sql
+git commit -m "Remove Layer 4 and rename layers in gks_vcv_statement_proc"
+```
+
+---
+
+## Chunk 2: RCV Aggregation Procedure
+
+### Task 3: Remove Layer 4 from gks-rcv-proc.sql
+
+**Files:**
+- Modify: `src/procedures/gks-rcv-proc.sql`
+
+Same pattern as Task 1, with RCV-specific names:
+
+- [ ] **Step 1: Remove Layer 4 DECLARE and the Layer 4 SQL block**
+
+Remove `DECLARE query_layer4 STRING;` and the entire Layer 4 block (lines 290-338).
+
+- [ ] **Step 2: Rename Layer 1-3 variables and table names**
+
+- `query_layer1` → `query_grouping_base`
+- `query_layer2` → `query_grouping_tier`
+- `query_layer3` → `query_agg_contribution`
+- `gks_rcv_layer1_base_agg` → `gks_rcv_grouping_base_agg`
+- `gks_rcv_layer2_tier_agg` → `gks_rcv_grouping_tier_agg`
+- `gks_rcv_layer3_prop_agg` → `gks_rcv_aggregate_contribution`
+
+- [ ] **Step 3: Update SQL comments**
+
+Same comment header pattern as Task 1 Step 3.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/procedures/gks-rcv-proc.sql
+git commit -m "Remove Layer 4 and rename layers in gks_rcv_proc"
+```
+
+---
+
+### Task 4: Remove Layer 4 from gks-rcv-statement-proc.sql
+
+**Files:**
+- Modify: `src/procedures/gks-rcv-statement-proc.sql`
+
+Same pattern as Task 2, with RCV-specific names:
+
+- [ ] **Step 1: Remove Layer 4 DECLARE variables**
+
+Remove `DECLARE query_layer4 STRING;` and `DECLARE query_l4_pre STRING;`.
+
+- [ ] **Step 2: Remove Layer 4 from cleanup_temp_tables call**
+
+Remove `'temp_rcv_layer4_statements'` and `'temp_rcv_layer4_pre'` from the cleanup array.
+
+- [ ] **Step 3: Remove Layer 4 BASE block**
+
+Delete the entire Layer 4 BASE section (lines 325-404).
+
+- [ ] **Step 4: Remove Layer 4 PRE block**
+
+Delete the entire Layer 4 PRE section (lines 557-610).
+
+- [ ] **Step 5: Simplify the FINAL union**
+
+Replace:
+```sql
+SELECT * FROM temp_rcv_layer4_pre
+UNION ALL
+SELECT * FROM temp_rcv_layer3_pre WHERE id LIKE '%-S-%'
+```
+
+With:
+```sql
+SELECT * FROM {P}.temp_rcv_agg_contribution_pre
+```
+
+- [ ] **Step 6: Remove Layer 4 DROP TABLE statements**
+
+Remove:
+- `DROP TABLE _SESSION.temp_rcv_layer4_statements;`
+- `DROP TABLE _SESSION.temp_rcv_layer4_pre;`
+
+- [ ] **Step 7: Rename all Layer 1-3 variables and table references**
+
+Same pattern as Task 2 Step 7 but with `rcv` prefix.
+
+- [ ] **Step 8: Update SQL comment headers**
+
+Same pattern as Task 2 Step 8.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/procedures/gks-rcv-statement-proc.sql
+git commit -m "Remove Layer 4 and rename layers in gks_rcv_statement_proc"
+```
+
+---
+
+## Chunk 3: Documentation Updates
+
+### Task 5: Update VCV aggregation rules doc
+
+**Files:**
+- Modify: `docs/pipeline/vcv-statements/vcv-aggregation-rules.md`
+
+- [ ] **Step 1: Rewrite the Layer Hierarchy section (lines 153-169)**
+
+Replace the "Layer Hierarchy" section with the new 2-layer model:
+
+```markdown
+## Aggregation Hierarchy
+
+VCV aggregation builds statements through a two-layer hierarchy. Each layer may consist of multiple SQL steps, but conceptually there are two aggregation layers.
+
+### Grouping Layer
+
+The Grouping Layer produces the initial aggregation of individual SCVs into groups. It consists of two steps that run as separate SQL operations but form a single conceptual layer:
+
+| Step | Name | Aggregates By | Description |
+| --- | --- | --- | --- |
+| Base Grouping | `gks_vcv_grouping_base_agg` | Variation + Statement Group + Proposition Type + Submission Level (+ Tier) | Lowest-level aggregation of individual SCVs. Applies submission-level-specific classification and conflict detection logic |
+| Tier Grouping | `gks_vcv_grouping_tier_agg` | Variation + Statement Group + Proposition Type + Submission Level | Combines tier-level groups (somatic sci only). Ranks tiers by priority, designates top tier as contributing |
+
+Tier Grouping applies only to somatic tiered records (`tier_grouping IS NOT NULL`). Non-tiered records (all germline and non-sci somatic) flow directly from Base Grouping to the Aggregate Contribution Layer.
+
+### Aggregate Contribution Layer
+
+| Step | Name | Aggregates By | Description |
+| --- | --- | --- | --- |
+| Aggregate Contribution | `gks_vcv_aggregate_contribution` | Variation + Statement Group + Proposition Type | Winner-takes-all across submission levels. This is the terminal layer for both germline and somatic statements |
+
+Submission levels are ranked `PG > EP > CP > NOCP > NOCL > FLAG`. The highest-ranked submission level becomes the "contributing" result; all others become "non-contributing" evidence.
+
+Each layer's output includes `evidenceLines` that reference the layer below, creating a nested structure in the final JSON output.
+```
+
+- [ ] **Step 2: Update any other references in the file**
+
+Check for and update any mentions of "four-layer", "Layer 4", "L4", "Group Aggregator" elsewhere in the document.
+
+- [ ] **Step 3: Run mkdocs build --strict to validate**
+
+```bash
+cd /Users/lbabb/Development/gks/clinvar-gks && mkdocs build --strict
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/pipeline/vcv-statements/vcv-aggregation-rules.md
+git commit -m "Update VCV aggregation rules for 2-layer model"
+```
+
+---
+
+### Task 6: Update VCV procedures doc
+
+**Files:**
+- Modify: `docs/pipeline/vcv-statements/vcv-proc.md`
+
+- [ ] **Step 1: Update gks_vcv_proc section**
+
+- Change "builds aggregation tables through a four-layer hierarchy" → "builds aggregation tables through a two-layer aggregation hierarchy"
+- Rename Step 2 header: "Build gks_vcv_layer1_base_agg" → "Build gks_vcv_grouping_base_agg"
+- Rename Step 3 header: "Build gks_vcv_layer2_tier_agg" → "Build gks_vcv_grouping_tier_agg"
+- Rename Step 4 header: "Build gks_vcv_layer3_prop_agg" → "Build gks_vcv_aggregate_contribution"
+- Delete Step 5 entirely (Layer 4 section)
+- Update all table name references throughout
+
+- [ ] **Step 2: Update gks_vcv_statement_proc section**
+
+- Change "9 sections: four BASE layers, four PRE layers" → "7 sections: three BASE steps, three PRE steps"
+- Rename "Layers 1--4 BASE" → "BASE Statement Steps"
+- Remove Layer 4 BASE description
+- Rename Layer 1/2/3 BASE descriptions with new names
+- Remove "Layer 4 PRE" section entirely
+- Rename Layer 1/2/3 PRE sections with new names
+- Update FINAL section: "Combines Layer 4 PRE (germline) and Layer 3 PRE (somatic)" → "Selects all Aggregate Contribution PRE statements"
+
+- [ ] **Step 3: Update Output Tables table**
+
+Replace all table names with new names and remove Layer 4 rows.
+
+- [ ] **Step 4: Update Dependencies section**
+
+Replace aggregation table references in the `gks_vcv_statement_proc` dependencies with new names.
+
+- [ ] **Step 5: Run mkdocs build --strict**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/pipeline/vcv-statements/vcv-proc.md
+git commit -m "Update VCV procedures doc for 2-layer model"
+```
+
+---
+
+### Task 7: Update VCV index page
+
+**Files:**
+- Modify: `docs/pipeline/vcv-statements/index.md`
+
+- [ ] **Step 1: Update key concepts and pipeline flow diagram**
+
+Replace "Four-layer hierarchy — L1 (base) through L4 (group)" with description of the two-layer model.
+
+Update the pipeline flow diagram:
+```text
+SCV Statements (gks_scv_statement_pre)
+         │
+         ▼
+┌──────────────────────────────────┐
+│  gks_vcv_proc                    │
+│  Grouping: Base                  │  Group by variation + group + prop + level [+ tier]
+│  Grouping: Tier                  │  Aggregate tiers within level (somatic only)
+│  Aggregate Contribution          │  Winner-takes-all across submission levels
+└───────────────┬──────────────────┘
+                │
+                ▼
+┌──────────────────────────────────┐
+│  gks_vcv_statement_proc          │
+│  BASE statements (3 steps)       │  Build statement structures from agg tables
+│  PRE: inline evidence (3 steps)  │  Propagate evidence through layers
+│  FINAL: select all               │  All Aggregate Contribution statements
+└───────────────┬──────────────────┘
+                │
+                ▼
+         gks_vcv_statement_pre
+```
+
+- [ ] **Step 2: Run mkdocs build --strict**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/pipeline/vcv-statements/index.md
+git commit -m "Update VCV index page for 2-layer model"
+```
+
+---
+
+### Task 8: Update RCV procedures doc
+
+**Files:**
+- Modify: `docs/pipeline/rcv-statements/rcv-proc.md`
+
+- [ ] **Step 1: Apply same changes as Task 6 but for RCV**
+
+Same pattern as Task 6. Key differences:
+- Table names use `rcv` prefix
+- Partition key is `rcv_accession` not `variation_id`
+- RCV has condition data resolution step (unchanged, but step numbering may shift)
+- Layer 4 PRE and Layer 4 BASE sections reference `rcv_accession` and `trait_set_id`
+
+Delete the entire Step 5 (Layer 4 group aggregator for RCV).
+
+- [ ] **Step 2: Update output tables**
+
+Replace table names and remove Layer 4 rows.
+
+- [ ] **Step 3: Run mkdocs build --strict**
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/pipeline/rcv-statements/rcv-proc.md
+git commit -m "Update RCV procedures doc for 2-layer model"
+```
+
+---
+
+### Task 9: Update RCV index page
+
+**Files:**
+- Modify: `docs/pipeline/rcv-statements/index.md`
+
+- [ ] **Step 1: Apply same changes as Task 7 but for RCV**
+
+Update the pipeline flow diagram and key concepts to match the 2-layer model.
+
+- [ ] **Step 2: Run mkdocs build --strict**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/pipeline/rcv-statements/index.md
+git commit -m "Update RCV index page for 2-layer model"
+```
+
+---
+
+### Task 10: Update glossary
+
+**Files:**
+- Modify: `docs/reference/glossary.md`
+
+- [ ] **Step 1: Rewrite the VCV Aggregation section (lines 173-203)**
+
+Replace Layer 1-4 definitions with:
+
+```markdown
+**Grouping Layer**
+:   First conceptual aggregation layer. Consists of Base Grouping and Tier Grouping steps. Produces initial aggregation of SCVs into groups by submission level.
+
+**Base Grouping** (Grouping Layer)
+:   First step of the Grouping Layer. Groups SCVs by variation + statement group + proposition type + submission level [+ tier]. Applies submission-level-specific classification and conflict detection logic.
+
+**Tier Grouping** (Grouping Layer)
+:   Second step of the Grouping Layer (somatic sci only). Aggregates tier-level groups within each submission level.
+
+**Aggregate Contribution Layer**
+:   Second and final aggregation layer. Applies winner-takes-all ranking across submission levels. Terminal layer for both germline and somatic statements.
+```
+
+Remove definitions for "Layer 4 (Statement Group)" and "Tier Grouping" (replaced by the above).
+
+- [ ] **Step 2: Run mkdocs build --strict**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/reference/glossary.md
+git commit -m "Update glossary for 2-layer aggregation model"
+```
+
+---
+
+### Task 11: Update output reference docs
+
+**Files:**
+- Modify: `docs/output-reference/vcv-statements.md`
+- Modify: `docs/output-reference/rcv-statements.md`
+- Modify: `docs/pipeline/vcv-statements/vcv-extensions.md`
+- Modify: `docs/pipeline/rcv-statements/rcv-extensions.md`
+
+- [ ] **Step 1: Rewrite Layer Hierarchy in vcv-statements.md (output-reference)**
+
+Replace the "Layer Hierarchy" section (lines 107-120) with the new 2-layer model:
+- Remove L4 row from the table
+- Change "4-layer aggregation hierarchy" to "2-layer"
+- Update "L4 for germline, L3 for somatic" (line 97) to "Aggregate Contribution Layer is the top level for both germline and somatic"
+- Rename L1/L2/L3 references to new names
+
+- [ ] **Step 2: Rewrite Layer Hierarchy in rcv-statements.md (output-reference)**
+
+Same changes as Step 1, applied to the RCV version (lines 176-187):
+- Remove L4 row, update "same 4-layer" to "same 2-layer"
+- Remove "Germline RCV statements use Layer 4 as the top level"
+
+- [ ] **Step 3: Update vcv-extensions.md**
+
+Change "Present only at Layer 1 for somatic clinical impact propositions" (line 108) to "Present only at the Base Grouping step for somatic clinical impact propositions".
+
+- [ ] **Step 4: Update rcv-extensions.md**
+
+Change "Present only at Layer 1 for somatic clinical impact propositions" (line 141) to "Present only at the Base Grouping step for somatic clinical impact propositions".
+Change "all four layers" (line 102) to "all aggregation steps".
+
+- [ ] **Step 5: Run mkdocs build --strict**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/output-reference/ docs/pipeline/vcv-statements/vcv-extensions.md docs/pipeline/rcv-statements/rcv-extensions.md
+git commit -m "Update output reference and extension docs for 2-layer model"
+```
+
+---
+
+## Chunk 4: Example File Updates
+
+### Task 12: Rename and rewrite VCV germline example
+
+**Files:**
+- Delete: `examples/vcv/VCV000012582.63-G.jsonc`
+- Create: `examples/vcv/VCV000012582.63-G-PATH.jsonc`
+
+- [ ] **Step 1: Rename VCV000012582.63-G.jsonc to VCV000012582.63-G-PATH.jsonc**
+
+```bash
+git mv examples/vcv/VCV000012582.63-G.jsonc examples/vcv/VCV000012582.63-G-PATH.jsonc
+```
+
+The old filename (`-G`) matched the L4 group aggregator ID format which no longer exists. The new filename (`-G-PATH`) matches the Aggregate Contribution Layer ID format.
+
+- [ ] **Step 2: Replace file content with Aggregate Contribution Layer format**
+
+The new structure is the content of what is currently the first nested evidence item (the L3 PATH statement) extracted as the top-level object. It should have:
+- ID: `VCV000012582.63-G-PATH`
+- `aggregateQualifiers: [AssertionGroup: "Germline", PropositionType: "Pathogenicity"]`
+- Contributing evidence: the CP-level Base Grouping statement (`VCV000012582.63-G-PATH-CP`)
+- Non-contributing evidence: the NOCP-level Base Grouping statement (`VCV000012582.63-G-PATH-NOCP`)
+- Top comment: `// Aggregate Contribution Layer — Germline Pathogenicity`
+
+The JSON structure is already present in the current file as the first `evidenceItems[0]` of the first `evidenceLines[0]`. Extract it and update comments.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/vcv/
+git commit -m "Rename and rewrite VCV germline example for 2-layer model"
+```
+
+---
+
+### Task 13: Update VCV PG/EP example comments
+
+**Files:**
+- Modify: `examples/vcv/VCV-PG-example.jsonc`
+- Modify: `examples/vcv/VCV-EP-example.jsonc`
+
+- [ ] **Step 1: Update layer comments in PG/EP examples**
+
+In each file, update comment references:
+- "Layer 1 Base" → "Grouping Layer — Base Grouping"
+- "Layer 3" → "Aggregate Contribution Layer"
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add examples/vcv/VCV-PG-example.jsonc examples/vcv/VCV-EP-example.jsonc
+git commit -m "Update VCV PG/EP example comments for 2-layer model"
+```
+
+---
+
+### Task 14: Update RCV example files
+
+**Files:**
+- Modify: `examples/rcv/RCV001781420.1-G-PATH.jsonc` (structural rewrite)
+- Modify: `examples/rcv/RCV006254391.1-S-SCI.jsonc` (comment updates)
+
+- [ ] **Step 1: Rewrite RCV001781420.1-G-PATH.jsonc**
+
+This file currently shows the L4 group aggregator output (comment says "RCV Layer 4 (Terminal for germline)"). Replace with the Aggregate Contribution Layer terminal format — the content of what is currently the L3 statement nested inside it.
+
+The new top-level should have `aggregateQualifiers: [AssertionGroup, PropositionType]` and ID format `RCV001781420.1-G-PATH`. Top comment: `// Aggregate Contribution Layer — Germline Pathogenicity`.
+
+- [ ] **Step 2: Update layer comments in somatic example**
+
+In `RCV006254391.1-S-SCI.jsonc`, update:
+- "RCV Layer 3 (Terminal for somatic)" → "Aggregate Contribution Layer"
+- "Layer 2 (tier aggregator)" → "Grouping Layer — Tier Grouping"
+- "Layer 1" → "Grouping Layer — Base Grouping"
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add examples/rcv/
+git commit -m "Update RCV example files for 2-layer model"
+```
+
+---
+
+### Task 15: Update examples doc references
+
+**Files:**
+- Modify: `docs/data-access/examples.md`
+
+- [ ] **Step 1: Update VCV examples table**
+
+Update descriptions that reference layer counts:
+- Germline row: update filename reference from `VCV000012582.63-G.jsonc` to `VCV000012582.63-G-PATH.jsonc`, change description from "Full 4-layer germline hierarchy (L4→L3→L1)" to describe the new Aggregate Contribution terminal format
+- `VCV000012582.63-S-sci.jsonc`: Change "3-layer somatic hierarchy (L3→L2→L1)" to use new naming (Aggregate Contribution → Grouping Tier → Grouping Base)
+- `VCV000012582.63-S-onco.jsonc`: Change "(L3→L1)" to use new naming
+- Update PG/EP descriptions that mention "Layer 1" or "Layer 3"
+
+- [ ] **Step 2: Run mkdocs build --strict**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/data-access/examples.md
+git commit -m "Update examples doc for 2-layer model"
+```
+
+---
+
+## Chunk 5: Validation
+
+### Task 16: Final validation
+
+- [ ] **Step 1: Run mkdocs build --strict**
+
+```bash
+cd /Users/lbabb/Development/gks/clinvar-gks && mkdocs build --strict
+```
+
+Verify no broken links or build errors.
+
+- [ ] **Step 2: Grep for stale references**
+
+Search entire codebase for any remaining references to old names:
+
+```bash
+grep -rn -E "layer[1-4]|Layer [1-4]|\bL[1-4]\b|four.layer|4.layer|layer1_base_agg|layer2_tier_agg|layer3_prop_agg|layer4_group_agg" \
+  --include="*.sql" --include="*.md" --include="*.jsonc" \
+  src/ docs/ examples/
+```
+
+Any hits (excluding `archive/` and `docs/superpowers/plans/`) indicate missed renames.
+
+- [ ] **Step 3: Verify SQL consistency**
+
+For each of the 4 SQL procedures, verify:
+
+1. All DECLARE'd variables are used
+2. All table names in CREATE match table names in subsequent references
+3. No dangling references to removed Layer 4 tables
+4. The cleanup_temp_tables arrays match the temp tables actually created
+
+- [ ] **Step 4: Commit any fixes and final commit**
+
+```bash
+git add -A
+git commit -m "Final validation fixes for aggregation layer refactor"
+```

--- a/docs/superpowers/plans/2026-04-23-replace-normalized-traits-with-gks-traits.md
+++ b/docs/superpowers/plans/2026-04-23-replace-normalized-traits-with-gks-traits.md
@@ -1,0 +1,240 @@
+# Replace temp_normalized_traits with gks_traits Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate the `temp_normalized_traits` temp table by using the already-computed persistent `gks_traits` table directly in the downstream assignment stages.
+
+**Architecture:** `gks_traits` (Step 1) and `temp_normalized_traits` (Step 5) both represent the same canonical trait data — trait IDs, names, types, MedGen IDs, and cross-reference IDs — but structured differently. `gks_traits` stores xrefs as a structured `mappings` array (`ARRAY<STRUCT<coding STRUCT<code, system, ...>, relation>>`) with MedGen in `primaryCoding`, while `temp_normalized_traits` uses flat arrays (`omim_ids`, `hp_ids`, etc.). The downstream consumers (Steps 10 and 11) can use `gks_traits` directly by UNNEST-ing the `mappings` array with system filters, eliminating the intermediate temp table and its deduplication logic.
+
+**Tech Stack:** BigQuery SQL stored procedures
+
+---
+
+## Analysis: Schema Mapping
+
+### temp_normalized_traits columns → gks_traits equivalents
+
+| temp_normalized_traits | gks_traits equivalent |
+|---|---|
+| `trait_id` | `trait_id` |
+| `trait_name` | `name` |
+| `trait_type` | `conceptType` |
+| `medgen_id` | `primaryCoding.code` |
+| `omim_ids` (ARRAY) | `UNNEST(mappings) WHERE coding.system = 'OMIM'` → `.coding.code` |
+| `hp_ids` (ARRAY) | `UNNEST(mappings) WHERE coding.system = 'Human Phenotype Ontology'` → `.coding.code` |
+| `mondo_ids` (ARRAY) | `UNNEST(mappings) WHERE coding.system = 'MONDO'` → `.coding.code` |
+| `orphanet_ids` (ARRAY) | `UNNEST(mappings) WHERE coding.system = 'Orphanet'` → `.coding.code` |
+| `mesh_ids` (ARRAY) | `UNNEST(mappings) WHERE coding.system IN ('MeSH', 'MSH')` → `.coding.code` |
+| `alternate_names` (ARRAY) | `SPLIT((SELECT e.value_string FROM UNNEST(extensions) e WHERE e.name = 'aliases'), ', ')` |
+
+### Key differences to be aware of
+
+1. **Data source**: `gks_traits` reads from `{S}.trait` (canonical). `temp_normalized_traits` reads from `temp_all_rcv_traits` (parsed RCV mapping XML). Same underlying traits, different parsing paths.
+
+2. **Scope**: `gks_traits` includes ALL traits. `temp_normalized_traits` only includes traits referenced by at least one RCV mapping. For rogue matching (Step 11), this means `gks_traits` may match against additional traits — which is acceptable and potentially improves coverage.
+
+3. **Deduplication**: `temp_normalized_traits` has complex dedup logic (keeping the record with more lookup values per `trait_id`). `gks_traits` already has one canonical record per `trait_id` via GROUP BY — no dedup needed.
+
+4. **IRI template filter**: `gks_traits` xrefs only include entries that have matching IRI templates in `clinvar_ingest.gks_xref_iri_templates`. All standard systems (MedGen, OMIM MIM, HP primary, MONDO, Orphanet, MeSH) have templates, so coverage is equivalent. `gks_traits` actually includes additional systems (EFO, GeneReviews, SNOMED CT, etc.).
+
+5. **Alternate names**: Stored as comma-separated string in `gks_traits.extensions` vs proper ARRAY in `temp_normalized_traits`. The round-trip SPLIT on `, ` is safe for medical condition names.
+
+---
+
+## Chunk 1: Rewrite downstream consumers and remove temp_normalized_traits
+
+### Task 1: Rewrite Step 10 (rcv_trait_assignment_stage3) to use gks_traits
+
+**Files:**
+- Modify: `src/procedures/gks-scv-condition-proc.sql` (Step 10, the `rcv_trait_direct_assignment` CTE)
+
+The 6 UNION ALL branches in `rcv_trait_direct_assignment` each join `temp_normalized_traits nt ON nt.trait_id = art.trait_id` then UNNEST a specific xref array. Replace each with a join to `gks_traits` and UNNEST of `mappings` filtered by system.
+
+- [ ] **Step 1: Replace the medgen_id branch**
+
+Current:
+```sql
+JOIN {P}.temp_normalized_traits nt
+  ON nt.trait_id = art.trait_id
+WHERE
+  ust.medgen_id = art.medgen_id
+```
+
+Replace with:
+```sql
+JOIN `{S}.gks_traits` gt
+  ON gt.trait_id = art.trait_id
+WHERE
+  ust.medgen_id = art.medgen_id
+```
+
+And update the SELECT to use `gt.trait_id`, `gt.name as trait_name`, `gt.conceptType as trait_type`, `gt.primaryCoding.code as trait_medgen_id`.
+
+- [ ] **Step 2: Replace the omim_id branch**
+
+Current:
+```sql
+JOIN {P}.temp_normalized_traits nt ON nt.trait_id = art.trait_id
+CROSS JOIN UNNEST(nt.omim_ids) as omim_id
+WHERE ust.omim_id = omim_id
+```
+
+Replace with:
+```sql
+JOIN `{S}.gks_traits` gt ON gt.trait_id = art.trait_id
+CROSS JOIN UNNEST(gt.mappings) as m
+WHERE m.coding.system = 'OMIM' AND ust.omim_id = m.coding.code
+```
+
+And update SELECT: `gt.trait_id`, `gt.name`, `gt.conceptType`, `gt.primaryCoding.code`.
+
+- [ ] **Step 3: Replace the hp_id branch**
+
+Same pattern. Filter: `m.coding.system = 'Human Phenotype Ontology'`. Match: `ust.hp_id = m.coding.code`.
+
+- [ ] **Step 4: Replace the mondo_id branch**
+
+Filter: `m.coding.system = 'MONDO'`. Match: `ust.mondo_id = m.coding.code`.
+
+- [ ] **Step 5: Replace the orphanet_id branch**
+
+Filter: `m.coding.system = 'Orphanet'`. Match: `ust.orphanet_id = m.coding.code`.
+
+- [ ] **Step 6: Replace the mesh_id branch**
+
+Filter: `m.coding.system IN ('MeSH', 'MSH')`. Match: `ust.mesh_id = m.coding.code`.
+
+---
+
+### Task 2: Rewrite Step 11 (rcv_trait_assignment_stage4) nt_lookup CTE to use gks_traits
+
+**Files:**
+- Modify: `src/procedures/gks-scv-condition-proc.sql` (Step 11, the `nt_lookup` CTE)
+
+The `nt_lookup` CTE explodes `temp_normalized_traits` into 8 priority-based rows per trait. Rewrite each UNION ALL branch to source from `gks_traits`.
+
+- [ ] **Step 1: Replace priority 1 (omim_ids)**
+
+Current:
+```sql
+SELECT trait_id, trait_name, trait_type, medgen_id as trait_medgen_id,
+  'rcv-scv rogue trait omim_id' as assign_type, 1 as priority, LOWER(xref_val) as match_value
+FROM {P}.temp_normalized_traits, UNNEST(omim_ids) as xref_val
+```
+
+Replace with:
+```sql
+SELECT gt.trait_id, gt.name as trait_name, gt.conceptType as trait_type, gt.primaryCoding.code as trait_medgen_id,
+  'rcv-scv rogue trait omim_id' as assign_type, 1 as priority, LOWER(m.coding.code) as match_value
+FROM `{S}.gks_traits` gt, UNNEST(gt.mappings) as m
+WHERE m.coding.system = 'OMIM'
+```
+
+- [ ] **Step 2: Replace priority 2 (hp_ids)**
+
+Same pattern. Filter: `m.coding.system = 'Human Phenotype Ontology'`. Assign type: `'rcv-scv rogue trait hp_id'`.
+
+- [ ] **Step 3: Replace priority 3 (orphanet_ids)**
+
+Filter: `m.coding.system = 'Orphanet'`. Assign type: `'rcv-scv rogue trait orphanet_id'`.
+
+- [ ] **Step 4: Replace priority 4 (mondo_ids)**
+
+Filter: `m.coding.system = 'MONDO'`. Assign type: `'rcv-scv rogue trait mondo_id'`.
+
+- [ ] **Step 5: Replace priority 5 (mesh_ids)**
+
+Filter: `m.coding.system IN ('MeSH', 'MSH')`. Assign type: `'rcv-scv rogue trait mesh_id'`.
+
+- [ ] **Step 6: Replace priority 6 (trait name)**
+
+Current:
+```sql
+SELECT trait_id, trait_name, trait_type, medgen_id,
+  'rcv-scv rogue trait name', 6, LOWER(trait_name)
+FROM {P}.temp_normalized_traits
+WHERE NOT (trait_name = 'not provided' AND trait_id IN ('54780', '76440','76481','78165','78166','78167'))
+```
+
+Replace with:
+```sql
+SELECT gt.trait_id, gt.name, gt.conceptType, gt.primaryCoding.code,
+  'rcv-scv rogue trait name', 6, LOWER(gt.name)
+FROM `{S}.gks_traits` gt
+WHERE NOT (gt.name = 'not provided' AND gt.trait_id IN ('54780', '76440','76481','78165','78166','78167'))
+```
+
+- [ ] **Step 7: Replace priority 7 (alternate names)**
+
+Current:
+```sql
+SELECT trait_id, trait_name, trait_type, medgen_id,
+  'rcv-scv rogue alternate trait name', 7, LOWER(alt_name)
+FROM {P}.temp_normalized_traits, UNNEST(alternate_names) as alt_name
+WHERE NOT (alt_name = 'not provided' AND trait_id IN ('54780', '76440','76481','78165','78166','78167'))
+```
+
+Replace with:
+```sql
+SELECT gt.trait_id, gt.name, gt.conceptType, gt.primaryCoding.code,
+  'rcv-scv rogue alternate trait name', 7, LOWER(alt_name)
+FROM `{S}.gks_traits` gt,
+  UNNEST(
+    SPLIT((SELECT e.value_string FROM UNNEST(gt.extensions) e WHERE e.name = 'aliases'), ', ')
+  ) as alt_name
+WHERE alt_name IS NOT NULL AND alt_name != ''
+  AND NOT (alt_name = 'not provided' AND gt.trait_id IN ('54780', '76440','76481','78165','78166','78167'))
+```
+
+- [ ] **Step 8: Replace priority 8 (medgen_id fallback)**
+
+Current:
+```sql
+SELECT trait_id, trait_name, trait_type, medgen_id,
+  'rcv-scv rogue trait name', 8, LOWER(medgen_id)
+FROM {P}.temp_normalized_traits
+```
+
+Replace with:
+```sql
+SELECT gt.trait_id, gt.name, gt.conceptType, gt.primaryCoding.code,
+  'rcv-scv rogue trait name', 8, LOWER(gt.primaryCoding.code)
+FROM `{S}.gks_traits` gt
+WHERE gt.primaryCoding IS NOT NULL
+```
+
+---
+
+### Task 3: Remove Step 5 (temp_normalized_traits) and clean up references
+
+**Files:**
+- Modify: `src/procedures/gks-scv-condition-proc.sql`
+
+- [ ] **Step 1: Remove the DECLARE statement**
+
+Delete: `DECLARE temp_normalized_traits_query STRING;`
+
+- [ ] **Step 2: Remove from cleanup list**
+
+Remove `'temp_normalized_traits'` from the `cleanup_temp_tables` call array.
+
+- [ ] **Step 3: Remove Step 5 entirely**
+
+Delete the entire block from `-- STEP 5: Create temp_normalized_traits` through `EXECUTE IMMEDIATE temp_normalized_traits_query;`.
+
+- [ ] **Step 4: Remove from DROP TABLE section**
+
+Delete: `DROP TABLE IF EXISTS _SESSION.temp_normalized_traits;`
+
+- [ ] **Step 5: Renumber subsequent steps**
+
+Update step comments:
+- Step 6 → Step 5
+- Step 7 → Step 6
+- Steps 8-13 → Steps 7-12
+
+- [ ] **Step 6: Verify no remaining references**
+
+Run: `grep -n 'temp_normalized_traits' src/procedures/gks-scv-condition-proc.sql`
+
+Expected: No matches.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,11 +22,15 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
   features:
+    - navigation.tabs
+    - navigation.tabs.sticky
     - navigation.sections
     - navigation.indexes
+    - navigation.top
     - search.suggest
     - search.highlight
     - content.code.copy
+    - toc.follow
 
 extra_css:
   - stylesheets/extra.css

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
       - RCV Extensions: pipeline/rcv-statements/rcv-extensions.md
   - Output Reference:
     - output-reference/index.md
+    - Output Format: output-reference/overview.md
     - Categorical Variants: output-reference/cat-vrs.md
     - SCV Statements: output-reference/scv-statements.md
     - VCV Statements: output-reference/vcv-statements.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -60,7 +60,7 @@ nav:
     - Output Format: output-reference/overview.md
     - Data Model:
       - output-reference/classes/index.md
-    - Categorical Variants: output-reference/cat-vrs.md
+    - Variations: output-reference/cat-vrs.md
     - SCV Statements: output-reference/scv-statements.md
     - VCV Statements: output-reference/vcv-statements.md
     - RCV Statements: output-reference/rcv-statements.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -36,7 +36,11 @@ markdown_extensions:
   - admonition
   - pymdownx.highlight:
       anchor_linenums: true
-  - pymdownx.superfences
+  - pymdownx.superfences:
+      custom_fences:
+        - name: mermaid
+          class: mermaid
+          format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.details
   - attr_list
   - md_in_html
@@ -46,6 +50,25 @@ markdown_extensions:
 nav:
   - Home: index.md
   - Getting Started: getting-started.md
+  - Data Access: data-access/index.md
+  # --- Understanding the Data ---
+  - Understanding the Data:
+    - Output Format: output-reference/overview.md
+    - Data Model:
+      - output-reference/classes/index.md
+    - Categorical Variants: output-reference/cat-vrs.md
+    - SCV Statements: output-reference/scv-statements.md
+    - VCV Statements: output-reference/vcv-statements.md
+    - RCV Statements: output-reference/rcv-statements.md
+    - ID References: output-reference/id-references.md
+    - Profiles:
+      - profiles/index.md
+      - Statement Types: profiles/statement-types.md
+      - Classifications: profiles/classifications.md
+      - Propositions: profiles/propositions.md
+      - Review Status: profiles/review-status.md
+    - Examples: data-access/examples.md
+  # --- Pipeline & Technical ---
   - Pipeline:
     - pipeline/index.md
     - Variation Identity:
@@ -79,32 +102,14 @@ nav:
       - pipeline/rcv-statements/index.md
       - RCV Procedures: pipeline/rcv-statements/rcv-proc.md
       - RCV Extensions: pipeline/rcv-statements/rcv-extensions.md
-  - Output Reference:
-    - output-reference/index.md
-    - Output Format: output-reference/overview.md
-    - Categorical Variants: output-reference/cat-vrs.md
-    - SCV Statements: output-reference/scv-statements.md
-    - VCV Statements: output-reference/vcv-statements.md
-    - RCV Statements: output-reference/rcv-statements.md
-    - ID References: output-reference/id-references.md
-  - Profiles:
-    - profiles/index.md
-    - Statement Types: profiles/statement-types.md
-    - Classifications: profiles/classifications.md
-    - Propositions: profiles/propositions.md
-    - Review Status: profiles/review-status.md
-  - Data Access:
-    - data-access/index.md
-    - Output Files: data-access/output-files.md
-    - Downloads: data-access/download.md
-    - Examples: data-access/examples.md
-  - Under Construction:
+  # --- Reference ---
+  - Reference:
+    - GA4GH Standards: reference/gks-standards.md
+    - Known Issues: reference/known-issues.md
+    - Glossary: reference/glossary.md
+  - Drafts:
     - drafts/index.md
     - ACMGv4 Variant Pathogenicity:
       - drafts/acmgv4-variant-pathogenicity/index.md
       - Case Data Model (Notes): drafts/acmgv4-variant-pathogenicity/ACMGv4-Case-DM.md
       - Case Schema & Matrix: drafts/acmgv4-variant-pathogenicity/ACMGv4-Case-DM-Schema.md
-  - Reference:
-    - reference/gks-standards.md
-    - Known Issues: reference/known-issues.md
-    - Glossary: reference/glossary.md

--- a/src/scripts/upload-gks-to-r2.sh
+++ b/src/scripts/upload-gks-to-r2.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
-# Upload ClinVar-GKS files from GCS public bucket to Cloudflare R2.
-# Runs after export-gks-files-to-gcs.sh has published files to GCS.
+# Upload ClinVar-GKS bundle file from GCS to Cloudflare R2.
+# Runs after export-gks-dicts.sh and assemble-gks-dicts.py have produced the bundle.
 #
 # Usage:
-#   ./upload-gks-to-r2.sh                    # Upload all 3 file types
-#   ./upload-gks-to-r2.sh variation           # Upload only variation
-#   ./upload-gks-to-r2.sh scv_by_ref scv_inline  # Upload specific types
+#   ./upload-gks-to-r2.sh                     # Upload current release
+#   ./upload-gks-to-r2.sh --dry-run           # Show what would be uploaded
+#   ./upload-gks-to-r2.sh --skip-current      # Only upload to dated archive
 #
-# Modes:
-#   --dry-run     Show what would be uploaded without uploading
-#   --skip-current  Only upload to the dated archive, not current/
-#   --backfill    Upload all historical files from GCS (ignores EXPORT_DATE)
+# Environment:
+#   Requires AWS CLI configured with an R2 profile.
+#   Set EXPORT_DATE and DATASET_VERSION below for each release.
 
 set -e
 
@@ -25,52 +24,37 @@ R2_PROFILE="r2"
 GCS_PUBLIC_BUCKET="clingen-public/clinvar-gks"
 
 # --- Export Configuration: Change these for each release ---
-EXPORT_DATE="2026-03-15"
-DATASET_VERSION="v2_4_3"
+EXPORT_DATE="2026-05-10"
+DATASET_VERSION="v2_5_0"
 
 # --- Derived values ---
-DATE_SUFFIX="${EXPORT_DATE//-/_}"
 YEAR="${EXPORT_DATE:0:4}"
 MONTH="${EXPORT_DATE:0:7}"
+ARCHIVE_PATH="${YEAR}/${MONTH}/${EXPORT_DATE}"
 
-# --- All output types ---
-ALL_OUTPUT_NAMES=("variation" "scv_by_ref" "scv_inline" "vcv" "rcv")
+# --- Bundle filename ---
+BUNDLE_FILENAME="clinvar-gks-${EXPORT_DATE}.json.gz"
+CURRENT_FILENAME="clinvar-gks-current.json.gz"
 
-# --- Parse flags and arguments ---
+# --- Parse flags ---
 DRY_RUN=false
 SKIP_CURRENT=false
-BACKFILL=false
-SELECTED_OUTPUTS=()
 
 for arg in "$@"; do
   case "$arg" in
-    --dry-run)     DRY_RUN=true ;;
+    --dry-run)      DRY_RUN=true ;;
     --skip-current) SKIP_CURRENT=true ;;
-    --backfill)    BACKFILL=true ;;
-    *)             SELECTED_OUTPUTS+=("$arg") ;;
+    *)
+      echo "ERROR: Unknown argument '${arg}'"
+      echo "Usage: $0 [--dry-run] [--skip-current]"
+      exit 1
+      ;;
   esac
-done
-
-# Default to all outputs if none specified
-if [ ${#SELECTED_OUTPUTS[@]} -eq 0 ]; then
-  SELECTED_OUTPUTS=("${ALL_OUTPUT_NAMES[@]}")
-fi
-
-# Validate output names
-for name in "${SELECTED_OUTPUTS[@]}"; do
-  valid=false
-  for valid_name in "${ALL_OUTPUT_NAMES[@]}"; do
-    if [[ "$name" == "$valid_name" ]]; then valid=true; break; fi
-  done
-  if ! $valid; then
-    echo "ERROR: Unknown output type '${name}'. Valid types: ${ALL_OUTPUT_NAMES[*]}"
-    exit 1
-  fi
 done
 
 # --- Helper functions ---
 r2_upload() {
-  local src="$1" dest="$2"
+  local src="$1" dest="$2" content_type="${3:-application/gzip}"
   if $DRY_RUN; then
     echo "  [dry-run] Would upload: ${dest}"
     return
@@ -78,210 +62,86 @@ r2_upload() {
   aws s3 cp "$src" "s3://${R2_BUCKET}/${dest}" \
     --endpoint-url "${R2_ENDPOINT}" \
     --profile "${R2_PROFILE}" \
-    --content-type "application/gzip" \
-    --quiet
-}
-
-r2_upload_json() {
-  local src="$1" dest="$2"
-  if $DRY_RUN; then
-    echo "  [dry-run] Would upload: ${dest}"
-    return
-  fi
-  aws s3 cp "$src" "s3://${R2_BUCKET}/${dest}" \
-    --endpoint-url "${R2_ENDPOINT}" \
-    --profile "${R2_PROFILE}" \
-    --content-type "application/json" \
+    --content-type "${content_type}" \
     --quiet
 }
 
 generate_manifest() {
-  local release_date="$1" version="$2" manifest_path="$3"
-  shift 3
-  local files=("$@")
-
-  local files_json=""
-  for f in "${files[@]}"; do
-    if [ -n "$files_json" ]; then files_json+=","; fi
-    files_json+="\"${f}\""
-  done
-
+  local manifest_path="$1"
   cat > "$manifest_path" <<MANIFEST
 {
-  "release_date": "${release_date}",
-  "schema_version": "${version}",
+  "release_date": "${EXPORT_DATE}",
+  "schema_version": "${DATASET_VERSION}",
   "generated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "files": [${files_json}]
+  "format": "bundle",
+  "files": ["${BUNDLE_FILENAME}"]
 }
 MANIFEST
 }
 
-# Build index.json from all manifests currently in R2.
-# Lists every release by scanning for manifest.json files in the archive paths.
-update_root_index() {
-  echo "Updating root index.json..."
-  local index_tmp="/tmp/r2_index.json"
+# --- Main ---
+echo "=== ClinVar-GKS Release Upload ==="
+echo "  Release:  ${EXPORT_DATE} (${DATASET_VERSION})"
+echo "  Bundle:   ${BUNDLE_FILENAME}"
+echo ""
 
-  # List all manifest.json files in the bucket (excluding current/)
-  local manifests
-  manifests=$(aws s3 ls "s3://${R2_BUCKET}/" --recursive --endpoint-url "${R2_ENDPOINT}" --profile "${R2_PROFILE}" \
-    | grep 'manifest.json' | grep -v 'current/' | awk '{print $4}' | sort)
-
-  if [ -z "$manifests" ]; then
-    echo "  No release manifests found in R2."
-    return
+# Check if bundle file exists in GCS
+GCS_URI="gs://${GCS_PUBLIC_BUCKET}/${EXPORT_DATE}/release/${BUNDLE_FILENAME}"
+echo "Checking GCS: ${GCS_URI}"
+if ! gsutil -q stat "${GCS_URI}" 2>/dev/null; then
+  # Try alternate path without release/ subdirectory
+  GCS_URI="gs://${GCS_PUBLIC_BUCKET}/${BUNDLE_FILENAME}"
+  if ! gsutil -q stat "${GCS_URI}" 2>/dev/null; then
+    echo "ERROR: Bundle file not found in GCS."
+    echo "  Tried: gs://${GCS_PUBLIC_BUCKET}/${EXPORT_DATE}/release/${BUNDLE_FILENAME}"
+    echo "  Tried: gs://${GCS_PUBLIC_BUCKET}/${BUNDLE_FILENAME}"
+    echo ""
+    echo "  Run export-gks-dicts.sh and assemble-gks-dicts.py first."
+    exit 1
   fi
-
-  # Build releases array by downloading each manifest
-  local releases_json="["
-  local first=true
-  while read -r manifest_key; do
-    # Extract path components: YYYY/YYYY-MM/YYYY-MM-DD/manifest.json
-    local release_path
-    release_path=$(dirname "$manifest_key")
-    local release_date
-    release_date=$(basename "$release_path")
-
-    # Fetch the manifest to get version and file list
-    local manifest_content
-    manifest_content=$(aws s3 cp "s3://${R2_BUCKET}/${manifest_key}" - \
-      --endpoint-url "${R2_ENDPOINT}" --profile "${R2_PROFILE}" 2>/dev/null)
-
-    local version
-    version=$(echo "$manifest_content" | python3 -c "import sys,json; print(json.load(sys.stdin)['schema_version'])" 2>/dev/null || echo "unknown")
-
-    local files_array
-    files_array=$(echo "$manifest_content" | python3 -c "import sys,json; print(json.dumps(json.load(sys.stdin)['files']))" 2>/dev/null || echo "[]")
-
-    if ! $first; then releases_json+=","; fi
-    first=false
-    releases_json+=$(printf '\n    {"date": "%s", "version": "%s", "path": "%s/", "files": %s}' \
-      "$release_date" "$version" "$release_path" "$files_array")
-  done <<< "$manifests"
-
-  releases_json+=$'\n  ]'
-
-  cat > "$index_tmp" <<INDEX
-{
-  "description": "ClinVar-GKS weekly data releases",
-  "updated_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
-  "base_url": "https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev",
-  "releases": ${releases_json}
-}
-INDEX
-
-  r2_upload_json "$index_tmp" "index.json"
-  rm -f "$index_tmp"
-  echo "  Root index.json updated."
-}
-
-upload_single_release() {
-  local export_date="$1" dataset_version="$2"
-  local date_suffix="${export_date//-/_}"
-  local year="${export_date:0:4}"
-  local month="${export_date:0:7}"
-  local archive_path="${year}/${month}/${export_date}"
-  local uploaded_files=()
-  local has_error=false
-
-  echo "=== Release: ${export_date} (${dataset_version}) ==="
-
-  for name in "${SELECTED_OUTPUTS[@]}"; do
-    local filename="clinvar_gks_${name}_${date_suffix}_${dataset_version}.jsonl.gz"
-    local gcs_uri="gs://${GCS_PUBLIC_BUCKET}/${filename}"
-    local local_tmp="/tmp/${filename}"
-
-    # Check if file exists in GCS
-    if ! gsutil -q stat "${gcs_uri}" 2>/dev/null; then
-      echo "  SKIP: ${filename} (not found in GCS)"
-      continue
-    fi
-
-    echo "  Downloading ${name}..."
-    if ! $DRY_RUN; then
-      gsutil -o "GSUtil:check_hashes=never" -q cp "${gcs_uri}" "${local_tmp}"
-    fi
-
-    # Upload to dated archive
-    echo "  Uploading ${name} to archive..."
-    r2_upload "${local_tmp}" "${archive_path}/${filename}"
-
-    # Upload to current/ (latest, stable URL)
-    if ! $SKIP_CURRENT; then
-      echo "  Uploading ${name} to current/..."
-      r2_upload "${local_tmp}" "current/clinvar_gks_${name}.jsonl.gz"
-    fi
-
-    uploaded_files+=("${filename}")
-
-    # Clean up temp file
-    if ! $DRY_RUN; then
-      rm -f "${local_tmp}"
-    fi
-
-    echo "  Done: ${name}"
-  done
-
-  # Generate and upload manifest for the dated archive
-  if [ ${#uploaded_files[@]} -gt 0 ]; then
-    local manifest_tmp="/tmp/manifest_${export_date}.json"
-    generate_manifest "${export_date}" "${dataset_version}" "${manifest_tmp}" "${uploaded_files[@]}"
-
-    echo "  Uploading archive manifest..."
-    r2_upload_json "${manifest_tmp}" "${archive_path}/manifest.json"
-
-    # Update current/ manifest (only if we uploaded to current/)
-    if ! $SKIP_CURRENT; then
-      echo "  Updating current/ manifest..."
-      r2_upload_json "${manifest_tmp}" "current/manifest.json"
-    fi
-
-    if ! $DRY_RUN; then
-      rm -f "${manifest_tmp}"
-    fi
-  fi
-
-  echo "=== Done: ${export_date} ==="
-  echo ""
-}
-
-# --- Backfill mode: discover and upload all releases from GCS ---
-if $BACKFILL; then
-  echo "Discovering releases in gs://${GCS_PUBLIC_BUCKET}/..."
-  # Extract unique release dates from GCS filenames
-  release_dates=$(gsutil ls "gs://${GCS_PUBLIC_BUCKET}/" | \
-    sed -n 's|.*clinvar_gks_variation_\([0-9_]*\)_v\(.*\)\.jsonl\.gz|\1 v\2|p' | \
-    sort -u)
-
-  if [ -z "$release_dates" ]; then
-    echo "No releases found in GCS."
-    exit 0
-  fi
-
-  echo "Found releases:"
-  echo "$release_dates" | while read -r date_part version; do
-    echo "  ${date_part//_/-} (${version})"
-  done
-  echo ""
-
-  # Process each release (oldest first, so current/ ends up with the newest)
-  echo "$release_dates" | while read -r date_part version; do
-    export_date="${date_part//_/-}"
-    upload_single_release "$export_date" "$version"
-  done
-
-  update_root_index
-  echo "Backfill complete."
-  exit 0
 fi
 
-# --- Normal mode: upload a single release ---
-upload_single_release "$EXPORT_DATE" "$DATASET_VERSION"
-update_root_index
+# Download from GCS
+LOCAL_TMP="/tmp/${BUNDLE_FILENAME}"
+echo "Downloading bundle from GCS..."
+if ! $DRY_RUN; then
+  gsutil -o "GSUtil:check_hashes=never" -q cp "${GCS_URI}" "${LOCAL_TMP}"
+fi
 
-echo "Upload complete."
-echo "  Archive: s3://${R2_BUCKET}/${YEAR}/${MONTH}/${EXPORT_DATE}/"
+# Upload to dated archive
+echo "Uploading to archive: ${ARCHIVE_PATH}/${BUNDLE_FILENAME}"
+r2_upload "${LOCAL_TMP}" "${ARCHIVE_PATH}/${BUNDLE_FILENAME}"
+
+# Upload to current/ with stable filename
 if ! $SKIP_CURRENT; then
-  echo "  Current: s3://${R2_BUCKET}/current/"
+  echo "Uploading to current: current/${CURRENT_FILENAME}"
+  r2_upload "${LOCAL_TMP}" "current/${CURRENT_FILENAME}"
+
+  # Also upload with dated name to current/ for weekly browsing
+  echo "Uploading to current: current/${BUNDLE_FILENAME}"
+  r2_upload "${LOCAL_TMP}" "current/${BUNDLE_FILENAME}"
 fi
-echo "  Public:  https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/"
+
+# Generate and upload manifest
+MANIFEST_TMP="/tmp/manifest_${EXPORT_DATE}.json"
+generate_manifest "${MANIFEST_TMP}"
+
+echo "Uploading archive manifest..."
+r2_upload "${MANIFEST_TMP}" "${ARCHIVE_PATH}/manifest.json" "application/json"
+
+if ! $SKIP_CURRENT; then
+  echo "Updating current/ manifest..."
+  r2_upload "${MANIFEST_TMP}" "current/manifest.json" "application/json"
+fi
+
+# Cleanup
+if ! $DRY_RUN; then
+  rm -f "${LOCAL_TMP}" "${MANIFEST_TMP}"
+fi
+
+echo ""
+echo "=== Upload Complete ==="
+echo "  Archive: https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/${ARCHIVE_PATH}/${BUNDLE_FILENAME}"
+if ! $SKIP_CURRENT; then
+  echo "  Current: https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/current/${CURRENT_FILENAME}"
+fi


### PR DESCRIPTION
## Summary
Comprehensive documentation revision for the bundle format, dictionary tables, and recent code changes.

### Tier 1 — Discovery & Overview (rewritten)
- Landing page with v1 coverage table, GA4GH standards, user personas
- Getting started guide with bundle format introduction and quick example
- Data access page with R2 URLs, release schedule, monthly archives
- Output format overview explaining bundle structure and `#/` references
- Output files and downloads pages for single bundle file

### Tier 2 — Understanding the Data (rewritten/revised)
- Data model page with Mermaid class relationship diagram
- Variations page (renamed from "Categorical Variants") with Cat-VRS recipe explanations
- SCV statements — MappableConcept patterns, proposition types/codes/predicates, evidence lines
- VCV statements — classification/priority/aggregate layer naming, strength values, evidence line refs
- RCV statements — condition-scoped aggregation, same patterns as VCV
- ID references — all `#/` reference patterns, resolution examples, proposition ID formats

### Navigation & Styling
- Tabbed header navigation (Material tabs.sticky)
- Reorganized nav by persona: Getting Started > Understanding the Data > Pipeline > Reference
- Reduced header-to-tabs spacing
- "Bundle" terminology replacing "dictionary" throughout

### Profiles & Reference
- Propositions: design consideration on proposition normalization
- Review status: added aggregate-only rank 2 statuses
- Glossary: updated terminology, removed old output file entries
- Variation terminology guidance (ClinVar terms first, Cat-VRS in context)

## Test plan
- [x] `mkdocs build --strict` passes (ignoring expected missing class stub pages)
- [ ] Review rendered site at localhost:8000
- [ ] Verify all internal links between new/revised pages
- [ ] Check Mermaid diagram renders correctly