### PR TITLE
Restructure docs nav and add extension reference tables

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -42,19 +42,152 @@ New releases are produced within a day or two after ClinVar's XML releases and a
 - **Platform engineers** building systems that consume ClinVar data and need a structured, well-documented format for integration
 - **GA4GH implementers** using ClinVar-GKS as a real-world validation of VRS, Cat-VRS, and VA-Spec schemas
 
-## How to Get the Data
+---
 
-The latest release is available as a single compressed JSON file:
+## Getting Started
 
-**Latest release:** [`https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/datasets/`](https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/datasets/)
+### Download the Latest Release
 
-See [Data Access](data-access/index.md) for the full release schedule, archive policy, and file format details.
+The latest ClinVar-GKS release is available as a single compressed JSON file:
+
+```bash
+# Download the latest monthly release
+curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/datasets/clinvar-gks_00-latest.json.gz
+
+# Decompress
+gunzip clinvar-gks_00-latest.json.gz
+```
+
+### What's in the File
+
+The release file is a single JSON object with **bundle sections** at the root level. Each section is a keyed collection of objects — the key is the object's unique identifier, and the value is the object itself.
+
+```json
+{
+  "sequenceReference": { "SQ.abc123": { ... } },
+  "location":          { "ga4gh:SL.xyz789": { ... } },
+  "allele":            { "ga4gh:VA.def456": { ... } },
+  "gene":              { "ncbigene:3077": { ... } },
+  "variation":         { "clinvar:10": { ... } },
+  "condition":         { "clinvar.trait:9580": { ... } },
+  "conditionSet":      { "clinvar.traitset:1234": { ... } },
+  "submitter":         { "clinvar.submitter:500139": { ... } },
+  "proposition":       { "SCV001234567-PATH": { ... } },
+  "scv":               { "clinvar.submission:SCV001234567.1": { ... } },
+  "vcv":               { "VCV000012582.63-G-PATH-CP": { ... } },
+  "rcv":               { "RCV000012345.8-G-PATH-CP": { ... } }
+}
+```
+
+Objects reference each other using `#/` JSON pointer strings. For example, an allele references its location as `"#/location/ga4gh:SL.xyz789"`, and an SCV statement references its proposition as `"#/proposition/SCV001234567-PATH"`.
+
+See [Output Format](output-reference/overview.md) for the full structure and reference patterns.
+
+### Quick Example
+
+To find the classification statements for a specific variant, start with the variation ID. ClinVar variation 10 (the HFE p.His63Asp variant) has the key `clinvar:10` in the `variation` section:
+
+```json
+{
+  "variation": {
+    "clinvar:10": {
+      "id": "clinvar:10",
+      "type": "CategoricalVariant",
+      "name": "NM_000410.4(HFE):c.187C>G (p.His63Asp)",
+      "members": ["#/allele/ga4gh:VA.ELQCnIBGqaTl0AEE0Az18XZ2cgIHAQIY"],
+      "constraints": [ ... ],
+      "extensions": [ ... ],
+      "mappings": [ ... ]
+    }
+  }
+}
+```
+
+The SCV statements for this variant reference it via `#/variation/clinvar:10` in their propositions. To find them, look for entries in the `proposition` section where `subjectVariant` matches, then find the corresponding `scv` entries that reference those propositions.
+
+### Key Concepts
+
+**Statements** are the core unit of ClinVar-GKS. Each statement represents a clinical classification — either submitted (SCV), aggregated per variation (VCV), or aggregated per condition (RCV). Statements carry:
+
+- A **classification** — the clinical significance label (e.g., Pathogenic, Likely benign)
+- A **proposition** — what the classification asserts (variant X causes condition Y)
+- **Direction** and **strength** — whether the evidence supports, disputes, or is neutral toward the proposition
+- **Evidence lines** — links to the contributing submissions or lower-level aggregations
+- **Extensions** — provenance metadata including submitted conditions, review status, and submission details
+
+**Propositions** define the relationship being classified — a variant's causal role for a condition, its oncogenic potential, or its clinical impact. Each proposition has a type (e.g., `VariantPathogenicityProposition`), a predicate (e.g., `isCausalFor`), a subject variant, and an object condition.
+
+**Conditions** represent the diseases or phenotypes that classifications are made against. Single conditions reference `#/condition/clinvar.trait:{id}`, while multi-condition sets reference `#/conditionSet/clinvar.traitSet:{id}`.
+
+---
+
+## Data Access
+
+ClinVar-GKS releases are published weekly as a single gzip-compressed JSON file, synchronized with each ClinVar XML release. The files are freely available for download from Cloudflare R2 object storage with no authentication required and no egress fees.
+
+### Release Schedule
+
+- **Weekly releases** are published to `datasets/weekly/`, one per ClinVar XML release
+- **Monthly releases** are created from the first weekly release of each month and published to `datasets/`
+- At the start of each month, the previous month's weekly files move to `archives/`
+- At the start of each year, the previous year's monthly files move to `archives/`
+
+The stable filenames `clinvar-gks_00-latest.json.gz` and `clinvar-gks_00-latest_weekly.json.gz` always point to the most recent monthly and weekly releases respectively.
+
+### Downloads
+
+Download the most recent monthly release:
+
+```bash
+curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/datasets/clinvar-gks_00-latest.json.gz
+```
+
+Download the most recent weekly release:
+
+```bash
+curl -O https://pub-9c5470edadb8496fb0abbf396291660b.r2.dev/datasets/weekly/clinvar-gks_00-latest_weekly.json.gz
+```
+
+### Directory Structure
+
+```text
+datasets/
+  clinvar-gks_00-latest.json.gz         latest monthly release
+  clinvar-gks_yyyy-mm.json.gz           monthly releases (current year)
+
+datasets/weekly/
+  clinvar-gks_00-latest_weekly.json.gz  latest weekly release
+  clinvar-gks_yyyy-mmdd.json.gz         weekly releases (current month)
+
+archives/{yyyy}/
+  clinvar-gks_yyyy-mm.json.gz           monthly releases from prior years
+
+archives/{yyyy}/weekly/
+  clinvar-gks_yyyy-mmdd.json.gz         weekly releases from prior months
+```
+
+### Release Notes
+
+Pipeline changes that affect the structure or content of the output are documented in the `release_notes/` directory. These notes cover additions, bug fixes, or schema changes specific to the ClinVar-GKS pipeline — they do not replicate ClinVar's own release notes.
+
+---
 
 ## How It Works
 
 The pipeline runs on **Google BigQuery** using SQL stored procedures, with an external VRS Python processing step. Each release is fully reprocessed from the source ClinVar XML — there is no incremental state between releases.
 
-See the [Pipeline Overview](pipeline/index.md) for the full workflow, or jump to [Getting Started](getting-started.md) for a quick introduction to the output format.
+See the [Pipeline Overview](pipeline/index.md) for the full workflow.
+
+---
+
+## Next Steps
+
+- [Output Format](output-reference/overview.md) — detailed guide to the bundle format
+- [Variations](output-reference/cat-vrs.md) — how ClinVar variations are represented
+- [SCV Statements](output-reference/scv-statements.md) — submitted classification statements
+- [Data Model](output-reference/classes/index.md) — class hierarchy and schema reference
+- [Pipeline Overview](pipeline/index.md) — how the data is produced from ClinVar XML
+- [Examples](data-access/examples.md) — annotated JSON examples
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -107,7 +107,7 @@ The SCV statements for this variant reference it via `#/variation/clinvar:10` in
 
 ### Key Concepts
 
-**Statements** are the core unit of ClinVar-GKS. Each statement represents a clinical classification — either submitted (SCV), aggregated per variation (VCV), or aggregated per condition (RCV). Statements carry:
+**Statements** are the core unit of ClinVar-GKS. Each statement represents a classification — either submitted (SCV), aggregated per variation (VCV), or aggregated per condition (RCV). Statements carry:
 
 - A **classification** — the clinical significance label (e.g., Pathogenic, Likely benign)
 - A **proposition** — what the classification asserts (variant X causes condition Y)

--- a/docs/output-reference/cat-vrs.md
+++ b/docs/output-reference/cat-vrs.md
@@ -34,7 +34,7 @@ Each record is a `CategoricalVariant` with the following top-level fields:
 | `constraints` | array | Defining constraints linking to the resolved VRS variant. See [Constraints](#constraints) |
 | `mappings` | array | Cross-references to external databases. See [Mappings](#mappings) |
 | `members` | array | `#/allele/` references to the defining VRS allele (empty for generalized variants) |
-| `extensions` | array | ClinVar metadata and supplementary data. See [Extensions](#extensions) |
+| `extensions` | array of [Extension](#extensions) | ClinVar-specific metadata and supplementary data (0..*). See [Extensions](#extensions) |
 
 </div>
 
@@ -112,18 +112,73 @@ The `mappings` array contains cross-references to external databases. Each mappi
 
 ## Extensions
 
-Extensions carry ClinVar-specific metadata not part of the core Cat-VRS specification. Each extension is a name/value pair. See [Categorical Variant Extensions](../pipeline/cat-vrs/catvar-extensions.md) for the complete reference with all extension types and custom structures.
+Extensions carry ClinVar-specific metadata not part of the core Cat-VRS specification. Each extension follows the GA4GH Extension structure: `{ "name": "<name>", "value": <value> }`. Extensions appear at two structural levels — on the top-level `CategoricalVariant` record and on nested `SequenceReference` objects.
 
-Common extensions:
+See [Categorical Variant Extensions (Pipeline)](../pipeline/cat-vrs/catvar-extensions.md) for details on how these extensions are built during pipeline processing.
+
+### CategoricalVariant Extensions
+
+<div class="field-table" markdown>
 
 | Extension Name | Value Type | Description |
-| --- | --- | --- |
-| `categoricalVariationType` | string | The Cat-VRS type — `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount` |
-| `clinvarVariationType` | string | ClinVar's variant type (e.g., `Deletion`, `single nucleotide variant`) |
-| `clinvarSubclassType` | string | ClinVar's subclass type (e.g., `SimpleAllele`, `Haplotype`) |
-| `clinvarCytogeneticLocation` | string | Chromosomal band location (e.g., `1p36.22`) |
-| `clinvarGeneList` | array | Gene associations with `#/gene/` references, relationship type, and source |
-| `clinvarHgvsList` | array | All HGVS expressions with molecular consequences and MANE designations |
+|---|---|---|
+| `categoricalVariationType` | `string` | The Cat-VRS category assigned to this variation: `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount`, or `Non-Constrained`. Determines which constraint types are generated. |
+| `definingVrsVariationType` | `string` | The VRS class assigned during variation identity processing (e.g., `Allele`, `CopyNumberChange`, `CopyNumberCount`, `Not Available`). Reflects the upstream classification used to route the variant through VRS processing. |
+| `clinvarVariationType` | `string` | The variation type as reported by ClinVar (e.g., `Deletion`, `single nucleotide variant`, `Duplication`, `Indel`). Present when ClinVar provides a variation type. |
+| `clinvarSubclassType` | `string` | The variation subclass as reported by ClinVar (e.g., `SimpleAllele`, `Haplotype`, `CompoundHeterozygote`). Present when ClinVar provides a subclass type. |
+| `clinvarCytogeneticLocation` | `string` | The cytogenetic band location of the variation (e.g., `1p36.22`, `17q21.31`). Present when ClinVar provides a cytogenetic location. |
+| `vrsPreProcessingIssue` | `string` | Issues detected during VRS pre-processing of the variation's input expressions. Present only when issues exist. May contain multiple issues separated by newlines. |
+| `vrsProcessingException` | `string` | Errors returned by the external VRS Python processing service. Present only when errors occurred during VRS resolution. |
+| `clinvarHgvsList` | array of [HgvsListItem](#hgvslistitem) | Complete list of HGVS expressions from ClinVar for this variation, including nucleotide and protein expressions, molecular consequences (SO terms), and MANE transcript designations. |
+| `clinvarGeneList` | array of [GeneListItem](#genelistitem) | Gene associations for this variation from ClinVar, including Entrez gene IDs, HGNC IDs, gene symbols, relationship types, and identifier IRIs. |
+
+</div>
+
+### SequenceReference Extensions
+
+Extensions on `SequenceReference` objects nested within `constraints[].allele.location.sequenceReference` and `members[].location.sequenceReference`.
+
+<div class="field-table" markdown>
+
+| Extension Name | Value Type | Description |
+|---|---|---|
+| `assembly` | `string` | The genome assembly name for this sequence reference (e.g., `GRCh38`, `GRCh37`, `NCBI36`). |
+
+</div>
+
+### HgvsListItem
+
+Each item in the `clinvarHgvsList` extension array represents one HGVS expression entry from ClinVar's `HGVSlist` element for the variation.
+
+<div class="field-table" markdown>
+
+| Field | Type | Description |
+|---|---|---|
+| `nucleotideExpression` | object | The nucleotide HGVS expression with `syntax` (e.g., `hgvs.c`, `hgvs.g`) and `value` (the HGVS string). |
+| `nucleotideType` | `string` | The type of nucleotide expression as reported by ClinVar (e.g., `coding`, `genomic`, `genomic, top-level`). |
+| `maneSelect` | `boolean` | `true` if this transcript is designated as MANE Select. Absent when not applicable. |
+| `manePlus` | `boolean` | `true` if this transcript is designated as MANE Plus Clinical. Absent when not applicable. |
+| `proteinExpression` | object | The protein HGVS expression with `syntax` (typically `hgvs.p`) and `value`. Present only when a protein-level expression exists for the nucleotide expression. |
+| `molecularConsequence` | array | Sequence Ontology terms describing the predicted molecular consequence. Each entry includes `code` (SO identifier), `system`, `name` (SO term label), and `iris` (identifiers.org link). |
+
+</div>
+
+### GeneListItem
+
+Each item in the `clinvarGeneList` extension array represents one gene association for the variation.
+
+<div class="field-table" markdown>
+
+| Field | Type | Description |
+|---|---|---|
+| `entrez_gene_id` | `string` | NCBI Entrez Gene identifier. |
+| `hgnc_id` | `string` | HGNC gene identifier (e.g., `HGNC:1234`). May be null for genes without an HGNC assignment. |
+| `symbol` | `string` | The gene symbol (e.g., `BRCA1`, `MTOR`). |
+| `relationship_type` | `string` | The relationship between the variation and the gene as reported by ClinVar (e.g., `within single gene`, `genes overlapped by variant`). |
+| `source` | `string` | The source of the gene association (e.g., `submitted`, `calculated`). |
+| `iris` | array | Identifier IRIs for the gene, including links to identifiers.org (HGNC and/or NCBI Gene) and NCBI Gene pages. |
+
+</div>
 
 ---
 

--- a/docs/output-reference/classes/index.md
+++ b/docs/output-reference/classes/index.md
@@ -8,62 +8,148 @@ This page provides a visual overview of how the classes relate to each other, wi
 
 ## Class Relationship Diagram
 
-The diagram below shows how the bundle classes relate to each other. Arrows indicate reference direction — for example, a Variation references its Allele members, and an SCV Statement references its Proposition.
+The diagram below shows how the bundle classes relate to each other in a UML-style view. Each class shows its key attributes. Lines indicate reference relationships — navigable from the class with the arrow. Multiplicity is shown on each end.
 
 ```mermaid
-flowchart LR
-    subgraph "<b>Genomic</b>"
-        direction TB
-        SR(["SequenceReference<br/><small>SQ.{digest}</small>"])
-        LOC(["Location<br/><small>ga4gh:SL.{digest}</small>"])
-        AL(["Allele<br/><small>ga4gh:VA.{digest}</small>"])
-        G(["Gene<br/><small>ncbigene:{id}</small>"])
-        V(["<b>Variation</b><br/><small>clinvar:{id}</small>"])
-    end
+classDiagram
+    direction TB
 
-    subgraph "<b>Clinical</b>"
-        direction TB
-        COND(["Condition<br/><small>clinvar.trait:{id}</small>"])
-        CS(["ConditionSet<br/><small>clinvar.traitset:{id}</small>"])
-        SUB(["Submitter<br/><small>clinvar.submitter:{id}</small>"])
-        PROP(["<b>Proposition</b><br/><small>{scv}-{CODE}</small>"])
-    end
+    namespace Variation {
+        class SequenceReference {
+            refgetAccession : string
+            residueAlphabet : string
+            molecularType : string
+            extensions : Extension[0..*]
+        }
+        class Location {
+            id : ga4gh:SL.digest
+            start : integer
+            end : integer
+        }
+        class Allele {
+            id : ga4gh:VA.digest
+            state : object
+            expressions : Expression[0..*]
+        }
+        class Gene {
+            id : ncbigene:id
+            symbol : string
+            hgnc_id : string
+        }
+        class CategoricalVariant {
+            id : clinvar:id
+            type : string
+            name : string
+            constraints : Constraint[0..*]
+            mappings : Mapping[0..*]
+            extensions : Extension[0..*]
+        }
+    }
 
-    subgraph "<b>Statements</b>"
-        direction TB
-        SCV(["<b>SCV</b><br/><small>clinvar.submission:{id}.{ver}</small>"])
-        VCV(["<b>VCV</b><br/><small>{vcv}-{group}-{prop}-{level}</small>"])
-        RCV(["<b>RCV</b><br/><small>{rcv}-{group}-{prop}-{level}</small>"])
-    end
+    namespace Supporting {
+        class Condition {
+            id : clinvar.trait:id
+            name : string
+            primaryCoding : Coding
+            mappings : Mapping[0..*]
+        }
+        class ConditionSet {
+            id : clinvar.traitset:id
+            operator : AND | OR
+        }
+        class Submitter {
+            id : clinvar.submitter:id
+            name : string
+        }
+        class Proposition {
+            id : string
+            type : string
+            predicate : string
+            geneContextQualifier : Concept[0..1]
+            modeOfInheritanceQualifier : Concept[0..1]
+            penetranceQualifier : Concept[0..1]
+        }
+    }
 
-    %% Genomic chain
-    LOC -- "#/sequenceReference/" --> SR
-    AL -- "#/location/" --> LOC
-    V -- "#/allele/" --> AL
-    V -. "#/gene/" .-> G
+    namespace Statements {
+        class ScvStatement {
+            id : clinvar.submission:id.ver
+            type : Statement
+            classification : MappableConcept
+            strength : MappableConcept
+            direction : string
+            confidence : string
+            contributions : Contribution[1..*]
+            specifiedBy : Method[0..1]
+            reportedIn : Publication[0..*]
+            extensions : Extension[0..*]
+        }
+        class VcvStatement {
+            id : VCV.ver-group-PROP-level
+            type : Statement
+            classification : MappableConcept
+            strength : MappableConcept
+            direction : string
+            confidence : string
+            extensions : Extension[0..*]
+        }
+        class RcvStatement {
+            id : RCV.ver-group-PROP-level
+            type : Statement
+            classification : MappableConcept
+            strength : MappableConcept
+            direction : string
+            confidence : string
+            extensions : Extension[0..*]
+        }
+        class EvidenceLine {
+            type : EvidenceLine
+            directionOfEvidenceProvided : string
+            strengthOfEvidenceProvided : MappableConcept
+        }
+    }
 
-    %% Clinical links
-    CS -- "#/condition/" --> COND
-    PROP -- "#/variation/" --> V
-    PROP -- "#/condition/" --> COND
-    PROP -. "#/conditionSet/" .-> CS
+    %% Variation relationships
+    Location "1" --> "1" SequenceReference : sequenceReference
+    Allele "1" --> "1" Location : location
+    CategoricalVariant "*" --> "0..*" Allele : members
+    CategoricalVariant "*" ..> "0..*" Gene : extensions.clinvarGeneList
 
-    %% Statement links
-    SCV -- "#/proposition/" --> PROP
-    SCV -- "#/submitter/" --> SUB
-    VCV -- "#/proposition/" --> PROP
-    VCV -- "#/scv/" --> SCV
-    VCV -. "#/vcv/" .-> VCV
-    RCV -- "#/proposition/" --> PROP
-    RCV -- "#/scv/" --> SCV
-    RCV -. "#/rcv/" .-> RCV
+    %% Supporting relationships
+    ConditionSet "1" --> "1..*" Condition : members
+    Proposition "*" --> "1" CategoricalVariant : subjectVariant
+    Proposition "*" --> "0..1" Condition : objectCondition
+    Proposition "*" --> "0..1" ConditionSet : objectCondition
+
+    %% Statement → Proposition
+    ScvStatement "1" --> "1" Proposition : proposition
+    VcvStatement "1" --> "1" Proposition : proposition
+    RcvStatement "1" --> "1" Proposition : proposition
+
+    %% Statement → Submitter
+    ScvStatement "*" --> "1..*" Submitter : contributions
+
+    %% Evidence lines
+    ScvStatement "1" --> "0..*" EvidenceLine : hasEvidenceLines
+    VcvStatement "1" --> "1..*" EvidenceLine : evidenceLines
+    RcvStatement "1" --> "1..*" EvidenceLine : evidenceLines
+
+    %% Evidence items (what evidence lines reference)
+    EvidenceLine "*" --> "1..*" ScvStatement : evidenceItems
+    EvidenceLine "*" ..> "0..*" VcvStatement : evidenceItems
+    EvidenceLine "*" ..> "0..*" RcvStatement : evidenceItems
 ```
 
-Solid arrows represent primary references. Dashed arrows represent optional or self-referencing relationships (e.g., VCV statements can reference lower-level VCV groupings, and genes are referenced from variation extensions).
+**Reading the diagram:**
+
+- **Solid lines** are primary associations — always present when the parent object exists
+- **Dashed lines** are optional or conditional associations (e.g., gene list from extensions, VCV/RCV self-referencing through evidence lines)
+- **Multiplicity** on each end indicates cardinality (e.g., `1` = exactly one, `0..*` = zero or more, `1..*` = one or more)
+- **Labels** on lines show the field name or JSON pointer path used for the reference
 
 ---
 
-## Genomic Classes
+## Variation Classes
 
 These classes represent the variant and its genomic context. VRS types (SequenceReference, Location, Allele) use their upstream GA4GH schemas directly. ClinVar-specific profiles are documented under [Variations](variations.md).
 
@@ -79,9 +165,9 @@ See [Variations](variations.md) for the full variant type hierarchy and extensio
 
 ---
 
-## Clinical Classes
+## Supporting Classes
 
-These classes represent the conditions, submitters, and propositions that support clinical classification statements. Conditions and submitters use upstream GA4GH types. ClinVar-specific proposition types are documented under [Propositions](propositions.md).
+These classes represent the conditions, submitters, and propositions that support classification statements. Conditions and submitters use upstream GA4GH types. ClinVar-specific proposition types are documented under [Propositions](propositions.md).
 
 | Class | Bundle Section | Key Pattern | Description |
 | --- | --- | --- | --- |
@@ -96,11 +182,11 @@ See [Propositions](propositions.md) for the full type/code/predicate reference.
 
 ## Statement Classes
 
-These classes represent clinical classification statements at different levels of aggregation. All are profiles of the VA-Spec Statement type documented under [Statements](statements.md).
+These classes represent classification statements at different levels of aggregation. All are profiles of the VA-Spec Statement type documented under [Statements](statements.md).
 
 | Class | Bundle Section | Key Pattern | Description |
 | --- | --- | --- | --- |
-| [ClinvarScvStatement](ClinvarScvStatement.md) | `scv` | `clinvar.submission:{id}.{ver}` | Submitted clinical classification |
+| [ClinvarScvStatement](ClinvarScvStatement.md) | `scv` | `clinvar.submission:{id}.{ver}` | Submitted classification |
 | [ClinvarVcvStatement](ClinvarVcvStatement.md) | `vcv` | `{vcv}-{group}-{prop}-{level}` | Variant-level aggregate |
 | [ClinvarRcvStatement](ClinvarRcvStatement.md) | `rcv` | `{rcv}-{group}-{prop}-{level}` | Condition-level aggregate |
 | [ClinvarSomaticEvidenceLine](ClinvarSomaticEvidenceLine.md) | (nested) | — | Somatic clinical impact evidence line |

--- a/docs/output-reference/classes/statements.md
+++ b/docs/output-reference/classes/statements.md
@@ -6,7 +6,7 @@ The [ClinvarStatement](ClinvarStatement.md) union type encompasses all three:
 
 | Level | Profile | Bundle Section | Description |
 | --- | --- | --- | --- |
-| Submission | [ClinvarScvStatement](ClinvarScvStatement.md) | `scv` | A single submitter's clinical classification |
+| Submission | [ClinvarScvStatement](ClinvarScvStatement.md) | `scv` | A single submitter's classification |
 | Variant aggregate | [ClinvarVcvStatement](ClinvarVcvStatement.md) | `vcv` | Aggregate across all submissions for a variant + proposition type |
 | Condition aggregate | [ClinvarRcvStatement](ClinvarRcvStatement.md) | `rcv` | Aggregate scoped to a specific variant + condition pair |
 
@@ -16,7 +16,7 @@ The [ClinvarStatement](ClinvarStatement.md) union type encompasses all three:
 
 Each SCV represents one submitter's assertion about a variant-condition relationship. SCV statements carry:
 
-- **Classification** — the submitter's clinical classification (e.g., Pathogenic, Likely benign, Tier I - Strong)
+- **Classification** — the submitter's classification (e.g., Pathogenic, Likely benign, Tier I - Strong)
 - **Direction** — whether the evidence `supports`, `disputes`, or is `neutral` toward the proposition
 - **Strength** — the strength of the assessment (e.g., definitive, likely)
 - **Contributions** — submitter identity and dates (submitted, created, evaluated) with `#/submitter/` references

--- a/docs/output-reference/overview.md
+++ b/docs/output-reference/overview.md
@@ -1,4 +1,4 @@
-# Output Format Overview
+# Output "Bundle" Format Overview
 
 The ClinVar-GKS release file uses a **bundle format** — a single JSON object with named sections at the root level. A bundle is a dictionary-style approach to organizing a large amount of data across heterogeneous classes in a single file, where each section is a keyed collection of objects of the same class. The key is the object's unique identifier, and the value is the complete object.
 
@@ -29,7 +29,7 @@ This design eliminates duplication (a sequence reference shared by thousands of 
 
 ## Sections
 
-### Genomic Data Sections
+### Variation Data Sections
 
 These sections contain the VRS and Cat-VRS variant data:
 
@@ -43,7 +43,7 @@ These sections contain the VRS and Cat-VRS variant data:
 
 **`variation`** — ClinVar variations with their defining constraints, cross-references, HGVS expressions, and gene associations. Most variations are represented as CanonicalAlleles with a defining VRS allele (via `#/allele/`); copy number variants use a defining location (via `#/location/`); complex variants use a generalized representation. Keyed by `clinvar:{variation_id}` (e.g., `clinvar:10`).
 
-### Clinical Data Sections
+### Supporting Data Sections
 
 These sections contain the condition, submitter, and proposition reference data:
 
@@ -57,9 +57,9 @@ These sections contain the condition, submitter, and proposition reference data:
 
 ### Statement Sections
 
-These sections contain the clinical classification statements:
+These sections contain the classification statements:
 
-**`scv`** — Submitted clinical classification statements. Each SCV carries a classification, strength, direction, proposition reference, contributions (with submitter references), evidence lines, citations, assertion method, and extensions with submitted condition provenance. Keyed by `clinvar.submission:{scv_id}.{version}`.
+**`scv`** — Submitted classification statements. Each SCV carries a classification, strength, direction, proposition reference, contributions (with submitter references), evidence lines, citations, assertion method, and extensions with submitted condition provenance. Keyed by `clinvar.submission:{scv_id}.{version}`.
 
 **`vcv`** — Variation-level aggregate classification statements. VCVs aggregate SCVs across a variation by classification, priority (somatic tiers), and submission level contribution. Evidence lines reference contributing SCVs via `#/scv/` or lower-level VCV groupings via `#/vcv/`. Keyed by the VCV layer ID.
 

--- a/docs/output-reference/rcv-statements.md
+++ b/docs/output-reference/rcv-statements.md
@@ -25,7 +25,7 @@ Each record is a `Statement` with the following top-level fields:
 | `strength` | object | MappableConcept — the aggregate evidence strength |
 | `direction` | string | `supports`, `disputes`, or `neutral` — derived from the aggregate classification |
 | `confidence` | string | Submission level label (e.g., `criteria provided`, `expert panel`) |
-| `extensions` | array | Aggregate metadata — `clinvarReviewStatus` |
+| `extensions` | array of [Extension](#extensions) | ClinVar-specific aggregate metadata (0..*). See [Extensions](#extensions) |
 | `evidenceLines` | array | Contributing and non-contributing evidence. See [Evidence Lines](#evidence-lines) |
 
 </div>
@@ -92,6 +92,46 @@ Evidence lines work identically to VCV. Each evidence line references contributi
 At the Classification layer, evidence items reference SCVs via `#/scv/`. At the Priority and Aggregate Contribution layers, evidence items reference lower-level RCV groupings via `#/rcv/`.
 
 See [VCV Evidence Lines](vcv-statements.md#evidence-lines) for the full field reference.
+
+---
+
+## Extensions
+
+Extensions carry aggregate metadata not part of the GA4GH VA-Spec statement model. Each extension follows the GA4GH Extension structure: `{ "name": "<name>", "value": <value> }`. Extensions appear at two structural levels — on the top-level `Statement` and on the `classification` object.
+
+RCV extensions follow the same patterns as [VCV extensions](vcv-statements.md#extensions). See [RCV Extensions (Pipeline)](../pipeline/rcv-statements/rcv-extensions.md) for details on how these extensions are built during pipeline processing.
+
+### Statement Extensions
+
+<div class="field-table" markdown>
+
+| Extension Name | Value Type | Description |
+|---|---|---|
+| `clinvarReviewStatus` | `string` | The aggregate review status derived from the submission level and aggregation outcome. Same value set as [VCV Statement Extensions](vcv-statements.md#statement-extensions). Always present. |
+
+</div>
+
+### Classification Extensions
+
+Extensions on the `classification` MappableConcept within the Statement.
+
+<div class="field-table" markdown>
+
+| Extension Name | Value Type | Description |
+|---|---|---|
+| `conflictingExplanation` | `string` | A formatted breakdown of conflicting classification counts (e.g., `Pathogenic(3); Likely pathogenic(2)`). Present only when the classification is conflicting. |
+
+</div>
+
+### SCI Classification Label Format
+
+For somatic clinical impact (SCI) propositions, the RCV aggregate classification label includes the tier, assertion type, and clinical significance:
+
+```text
+<tier_label> - <assertion_type> - <clinical_significance> (<scv_count>)
+```
+
+Examples: `Tier I - Strong - diagnostic - supports diagnosis (1)`, `Tier II - Potential - prognostic - poor outcome (1)`
 
 ---
 

--- a/docs/output-reference/scv-statements.md
+++ b/docs/output-reference/scv-statements.md
@@ -29,7 +29,7 @@ Each record is a VA-Spec `Statement` with the following top-level fields:
 | `contributions` | array | Submitter and date information with `#/submitter/` references. See [Contributions](#contributions) |
 | `specifiedBy` | object | The classification method/guideline used |
 | `reportedIn` | array | Supporting publications (PubMed, DOI references) |
-| `extensions` | array | ClinVar-specific metadata. See [Extensions](#extensions) |
+| `extensions` | array of [Extension](#extensions) | ClinVar-specific metadata (0..*). See [Extensions](#extensions) |
 | `hasEvidenceLines` | array | Evidence lines for somatic clinical impact assertions. See [Evidence Lines](#evidence-lines) |
 
 </div>
@@ -176,19 +176,93 @@ The `evidenceOutcome` is a MappableConcept with `conceptType: "Outcome"` indicat
 
 ## Extensions
 
-The `extensions` array carries ClinVar-specific metadata:
+Extensions carry ClinVar-specific metadata not part of the GA4GH VA-Spec statement model. Each extension follows the GA4GH Extension structure: `{ "name": "<name>", "value": <value> }`. Extensions appear at three structural levels — on the top-level `Statement`, on the `classification` object, and on proposition qualifier objects.
+
+See [SCV Extensions (Pipeline)](../pipeline/scv-statements/scv-extensions.md) for details on how these extensions are built during pipeline processing.
+
+### Statement Extensions
+
+<div class="field-table" markdown>
 
 | Extension Name | Value Type | Description |
-| --- | --- | --- |
-| `clinvarScvId` | string | SCV accession without version (e.g., `SCV002769510`) |
-| `clinvarScvVersion` | string | SCV version number |
-| `submittedCondition` / `submittedConditionSet` | object | Submitted condition provenance with normalization details, trait mapping, and `#/condition/` references |
-| `clinvarScvReviewStatus` | string | ClinVar review status (e.g., `criteria provided, single submitter`) |
-| `submittedScvClassification` | string | Original submitted classification (when it differs from the normalized label) |
-| `submittedScvLocalKey` | string | Submitter's local key for the record |
-| `submissionLevel` | string | Submission level code (e.g., `CP`, `EP`, `PG`) |
+|---|---|---|
+| `clinvarScvId` | `string` | The ClinVar SCV accession without version (e.g., `SCV001571657`). Always present. |
+| `clinvarScvVersion` | `string` | The version number of the SCV submission (e.g., `2`). Always present. |
+| `submittedCondition` | [SubmittedCondition](#submittedcondition) | Submitted condition provenance with normalization details, trait mapping, and `#/condition/` references. Present when the SCV maps to a single condition. |
+| `submittedConditionSet` | [SubmittedConditionSet](#submittedconditionset) | Submitted condition set provenance with multiple condition concepts. Present when the SCV maps to multiple conditions. |
+| `clinvarScvReviewStatus` | `string` | The ClinVar review status (e.g., `criteria provided, single submitter`). Present when the SCV has a review status. |
+| `submittedScvClassification` | `string` | The original classification text submitted by the submitter, preserved when it differs from the normalized classification name. |
+| `submittedScvLocalKey` | `string` | The unique local key provided by the submitter for this submission. Present only when the submitter provided a local key. |
+| `submissionLevel` | `string` | The submission level code: `PG`, `EP`, `CP`, `NOCP`, `NOCL`, or `FLAG`. Present when the submission level can be determined. |
 
-See [SCV Extensions](../pipeline/scv-statements/scv-extensions.md) for the complete extension reference.
+</div>
+
+!!! note
+    Only one of `submittedCondition` or `submittedConditionSet` is present per SCV — never both. The `submittedScvClassification` extension is omitted when the submitted classification matches the normalized label exactly.
+
+### Classification Extensions
+
+Extensions on the `classification` MappableConcept within the Statement.
+
+<div class="field-table" markdown>
+
+| Extension Name | Value Type | Description |
+|---|---|---|
+| `description` | `string` | A formatted multi-line description summarizing the classification context: condition name, submission level, evaluation date, and submitter name. Always present. |
+
+</div>
+
+The description template is: `for <condition_name>\nClassification is based on the <submission_level_label> submission\n<evaluated_date> by <submitter_name>`.
+
+### Qualifier Extensions
+
+Extensions on proposition qualifier objects (`geneContextQualifier`, `modeOfInheritanceQualifier`, `penetranceQualifier`), preserving the original submitter-provided values.
+
+<div class="field-table" markdown>
+
+| Extension Name | Value Type | Description |
+|---|---|---|
+| `submittedGeneSymbols` | array of `string` | Gene symbols originally submitted by the submitter. Present on `geneContextQualifier` when the submitter provided gene information. May differ from the normalized gene symbol. |
+| `submittedModeOfInheritance` | `string` | Mode of inheritance text as originally submitted. Present on all `modeOfInheritanceQualifier` objects. Preserved alongside the normalized HPO coding. |
+| `submittedClassification` | `string` | Original submitted classification text that triggered the penetrance qualifier derivation. Present on all `penetranceQualifier` objects. |
+
+</div>
+
+### SubmittedCondition
+
+The `submittedCondition` extension captures the provenance of how a single submitted condition was mapped to the normalized ClinVar trait. Present when the SCV maps to exactly one condition.
+
+<div class="field-table" markdown>
+
+| Field | Type | Description |
+|---|---|---|
+| `condition` | `string` | `#/condition/clinvar.trait:{id}` reference to the normalized condition in the bundle. |
+| `conditionSet` | `string` | `#/conditionSet/clinvar.traitset:{id}` reference (present when the RCV trait set has one trait but the reference uses the set). |
+| `id` | `string` | The submitted clinical assertion trait ID (e.g., `SCV002769510.0`). |
+| `name` | `string` | The submitted condition name. |
+| `type` | `string` | The submitted condition type (e.g., `Disease`, `Finding`). |
+| `medgen_id` | `string` | The submitted or resolved MedGen concept ID. |
+| `normalized_match` | `string` | `#/condition/` reference to the matched normalized trait. |
+| `normalized_resolution` | `string` | The resolution method used to match the submitted condition (e.g., `tm reftype xref omim`, `random trait assignment`). |
+| `xrefs` | array | Submitted cross-references with `code` and `system`. |
+| `mapping` | object | The trait mapping entry used for resolution: `type`, `ref`, `value`. |
+
+</div>
+
+### SubmittedConditionSet
+
+The `submittedConditionSet` extension captures provenance for multi-condition submissions. Present when the SCV maps to more than one condition.
+
+<div class="field-table" markdown>
+
+| Field | Type | Description |
+|---|---|---|
+| `conditionSet` | `string` | `#/conditionSet/clinvar.traitset:{id}` reference. |
+| `condition` | `string` | `#/condition/clinvar.trait:{id}` reference (present when the RCV set resolves to a single trait). |
+| `multiple_condition_explanation` | `string` | ClinVar's explanation for the multi-condition grouping. |
+| `concepts` | array | Array of individual condition provenance objects, each with the same fields as [SubmittedCondition](#submittedcondition). |
+
+</div>
 
 ---
 

--- a/docs/output-reference/scv-statements.md
+++ b/docs/output-reference/scv-statements.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `scv` bundle section contains one record per ClinVar submitted clinical assertion (SCV). Each record is a VA-Spec `Statement` that captures a submitter's clinical interpretation of a variant — including the classification, evidence, condition, variant, and method.
+The `scv` bundle section contains one record per ClinVar submission (SCV). Each record is a VA-Spec `Statement` that captures a submitter's interpretation of a variant — including the classification, evidence, condition, variant, and method.
 
 SCV statements use `#/` references to link to propositions, submitters, and conditions in their respective bundle sections rather than embedding full objects inline.
 
@@ -21,7 +21,7 @@ Each record is a VA-Spec `Statement` with the following top-level fields:
 | `id` | string | SCV accession with version — `clinvar.submission:SCV000123456.1` |
 | `type` | string | Always `Statement` |
 | `proposition` | string | `#/proposition/{id}` reference to the classification proposition |
-| `classification` | object | MappableConcept — the submitter's clinical classification. See [Classification](#classification) |
+| `classification` | object | MappableConcept — the submitter's classification. See [Classification](#classification) |
 | `strength` | object | MappableConcept — the evidence strength. See [Strength](#strength) |
 | `direction` | string | Whether the evidence `supports`, `disputes`, or is `neutral` toward the proposition |
 | `confidence` | string | Submission level label (e.g., `criteria provided`, `practice guideline`) |
@@ -38,7 +38,7 @@ Each record is a VA-Spec `Statement` with the following top-level fields:
 
 ## Classification
 
-The `classification` field is a MappableConcept with the submitted clinical significance:
+The `classification` field is a MappableConcept with the submitted classification:
 
 ```json
 {

--- a/docs/output-reference/vcv-statements.md
+++ b/docs/output-reference/vcv-statements.md
@@ -23,7 +23,7 @@ Each record is a `Statement` with the following top-level fields:
 | `strength` | object | MappableConcept — the aggregate evidence strength. See [Strength](#strength) |
 | `direction` | string | `supports`, `disputes`, or `neutral` — derived from the aggregate classification |
 | `confidence` | string | Submission level label (e.g., `criteria provided`, `expert panel`) |
-| `extensions` | array | Aggregate metadata — `clinvarReviewStatus` |
+| `extensions` | array of [Extension](#extensions) | ClinVar-specific aggregate metadata (0..*). See [Extensions](#extensions) |
 | `evidenceLines` | array | Contributing and non-contributing evidence. See [Evidence Lines](#evidence-lines) |
 
 </div>
@@ -115,6 +115,36 @@ Each VCV statement contains `evidenceLines` — an array of evidence line object
 | `evidenceItems` | array | `#/scv/` references (at classification layer) or `#/vcv/` references (at priority/aggregate layers) |
 
 Contributing evidence lines use `directionOfEvidenceProvided: "supports"`. Non-contributing evidence lines (lower-ranked submission levels) use `directionOfEvidenceProvided: "neutral"`.
+
+---
+
+## Extensions
+
+Extensions carry aggregate metadata not part of the GA4GH VA-Spec statement model. Each extension follows the GA4GH Extension structure: `{ "name": "<name>", "value": <value> }`. Extensions appear at two structural levels — on the top-level `Statement` and on the `classification` object.
+
+See [VCV Extensions (Pipeline)](../pipeline/vcv-statements/vcv-extensions.md) for details on how these extensions are built during pipeline processing.
+
+### Statement Extensions
+
+<div class="field-table" markdown>
+
+| Extension Name | Value Type | Description |
+|---|---|---|
+| `clinvarReviewStatus` | `string` | The aggregate review status derived from the submission level and aggregation outcome. Always present. Values: `practice guideline`, `reviewed by expert panel`, `criteria provided, single submitter`, `criteria provided, multiple submitters, no conflicts`, `criteria provided, conflicting classifications`, `no assertion criteria provided`, `no classification provided`, `flagged submission`. |
+
+</div>
+
+### Classification Extensions
+
+Extensions on the `classification` MappableConcept within the Statement.
+
+<div class="field-table" markdown>
+
+| Extension Name | Value Type | Description |
+|---|---|---|
+| `conflictingExplanation` | `string` | A formatted breakdown of conflicting classification counts (e.g., `Pathogenic(3); Likely pathogenic(2)`). Present only when the classification is conflicting — multiple distinct significance values exist for a conflict-detectable proposition type. |
+
+</div>
 
 ---
 

--- a/docs/pipeline/cat-vrs/catvar-extensions.md
+++ b/docs/pipeline/cat-vrs/catvar-extensions.md
@@ -2,6 +2,9 @@
 
 ## Overview
 
+!!! tip "Schema Reference"
+    For the canonical extension reference tables (extension names, value types, and descriptions), see [Variations — Extensions](../../output-reference/cat-vrs.md#extensions).
+
 Categorical variant records contain `extensions` arrays at multiple levels of the JSON structure. Extensions carry ClinVar-specific information, VRS processing details, and linked data that are not part of the GA4GH Cat-VRS specification but are essential for clinical interpretation.
 
 All extensions follow the structure `{ "name": "<extension_name>", "value": <value> }`, where the value type varies by extension. Most extensions carry simple scalar values (string, boolean, etc.). Extensions with complex value types — arrays of structured objects — are documented as custom extension structures in a [dedicated section](#custom-extension-structures) below.

--- a/docs/pipeline/cat-vrs/catvar-extensions.md
+++ b/docs/pipeline/cat-vrs/catvar-extensions.md
@@ -5,7 +5,7 @@
 !!! tip "Schema Reference"
     For the canonical extension reference tables (extension names, value types, and descriptions), see [Variations — Extensions](../../output-reference/cat-vrs.md#extensions).
 
-Categorical variant records contain `extensions` arrays at multiple levels of the JSON structure. Extensions carry ClinVar-specific information, VRS processing details, and linked data that are not part of the GA4GH Cat-VRS specification but are essential for clinical interpretation.
+Categorical variant records contain `extensions` arrays at multiple levels of the JSON structure. Extensions carry ClinVar-specific information, VRS processing details, and linked data that are not part of the GA4GH Cat-VRS specification but are essential for interpreting the data.
 
 All extensions follow the structure `{ "name": "<extension_name>", "value": <value> }`, where the value type varies by extension. Most extensions carry simple scalar values (string, boolean, etc.). Extensions with complex value types — arrays of structured objects — are documented as custom extension structures in a [dedicated section](#custom-extension-structures) below.
 

--- a/docs/pipeline/rcv-statements/rcv-extensions.md
+++ b/docs/pipeline/rcv-statements/rcv-extensions.md
@@ -2,6 +2,9 @@
 
 ## Overview
 
+!!! tip "Schema Reference"
+    For the canonical extension reference tables (extension names, value types, and descriptions), see [RCV Statements — Extensions](../../output-reference/rcv-statements.md#extensions).
+
 RCV aggregate statement records contain `extensions` arrays at two structural levels — on the top-level `Statement` and on the `classification` object. Extensions carry aggregate review status information and classification context that are not part of the GA4GH VA-Spec statement model but are essential for interpreting the aggregation outcome.
 
 RCV extensions follow the same patterns as [VCV extensions](../vcv-statements/vcv-extensions.md). The key structural difference is that RCV statements are scoped to a specific condition — the condition reference is on the proposition (via `#/condition/` or `#/conditionSet/`), not embedded in the extensions.

--- a/docs/pipeline/scv-statements/scv-extensions.md
+++ b/docs/pipeline/scv-statements/scv-extensions.md
@@ -2,6 +2,9 @@
 
 ## Overview
 
+!!! tip "Schema Reference"
+    For the canonical extension reference tables (extension names, value types, and descriptions), see [SCV Statements — Extensions](../../output-reference/scv-statements.md#extensions).
+
 SCV statement records contain `extensions` arrays at three structural levels — on the top-level `Statement`, on the `classification` object, and on proposition qualifier objects (`geneContextQualifier`, `modeOfInheritanceQualifier`, `penetranceQualifier`). Extensions carry ClinVar-specific metadata, submitter-provided values, and formatted descriptions that are not part of the GA4GH VA-Spec statement model but are essential for tracing how each SCV was processed.
 
 All extensions follow the structure `{ "name": "<extension_name>", "value": <value> }`, where the value type varies by extension. Most extensions carry simple string values. Extensions with complex value types — structured condition provenance objects — are documented as custom extension structures in a [dedicated section](#custom-extension-structures) below.

--- a/docs/pipeline/vcv-statements/vcv-extensions.md
+++ b/docs/pipeline/vcv-statements/vcv-extensions.md
@@ -2,6 +2,9 @@
 
 ## Overview
 
+!!! tip "Schema Reference"
+    For the canonical extension reference tables (extension names, value types, and descriptions), see [VCV Statements — Extensions](../../output-reference/vcv-statements.md#extensions).
+
 VCV aggregate statement records contain `extensions` arrays at two structural levels — on the top-level `Statement` and on the `classification` object. Extensions carry aggregate review status information and classification context that are not part of the GA4GH VA-Spec statement model but are essential for interpreting the aggregation outcome.
 
 All extensions follow the structure `{ "name": "<extension_name>", "value": <value> }`.

--- a/docs/profiles/index.md
+++ b/docs/profiles/index.md
@@ -4,7 +4,7 @@ This section describes the fundamental aspects of how ClinVar data is organized 
 
 ## Overview
 
-ClinVar submissions (SCVs) are the baseline statements submitted to ClinVar by clinical laboratories, expert panels, and other organizations. ClinVar aggregates these submissions using different rules for specific statement types to produce higher-order statements (RCVs and VCVs).
+ClinVar submissions (SCVs) are the baseline statements submitted to ClinVar by laboratories, expert panels, research groups, locus-specific databases (LSDBs), and other organizations. ClinVar aggregates these submissions using different rules for specific statement types to produce higher-order statements (RCVs and VCVs).
 
 ClinVar-GKS maps each submission to a specific **statement type**, **proposition profile**, and **classification** with corresponding **direction** and **strength** values conforming to the GA4GH VA-Spec standard.
 

--- a/docs/reference/glossary.md
+++ b/docs/reference/glossary.md
@@ -10,7 +10,7 @@ Key terms, acronyms, and concepts used throughout the ClinVar-GKS documentation.
 :   International consortium developing standards for genomic data representation and exchange.
 
 **GKS** (Genomic Knowledge Standards)
-:   Collective term for GA4GH standards — VRS, Cat-VRS, and VA-Spec — for representing genomic variants and clinical assertions.
+:   Collective term for GA4GH standards — VRS, Cat-VRS, and VA-Spec — for representing genomic variants and variant assertions.
 
 **VRS** (Variation Representation Specification)
 :   GA4GH standard for normalized, computable variant identifiers. Defines how variants are represented with sequence references, locations, and states.
@@ -19,7 +19,7 @@ Key terms, acronyms, and concepts used throughout the ClinVar-GKS documentation.
 :   GA4GH standard for categorical variant representations that group variants at a higher level — CanonicalAlleles, CategoricalCnvChange, CategoricalCnvCount.
 
 **VA-Spec** (Variant Annotation Specification)
-:   GA4GH standard for clinical variant statements. Defines the Statement, Proposition, and EvidenceLine structures used by SCV and VCV outputs.
+:   GA4GH standard for variant annotation statements. Defines the Statement, Proposition, and EvidenceLine structures used by SCV and VCV outputs.
 
 **ACMG** (American College of Medical Genetics and Genomics)
 :   Organization that publishes pathogenicity classification guidelines (2015, v4) used by ClinVar submitters.
@@ -32,10 +32,10 @@ Key terms, acronyms, and concepts used throughout the ClinVar-GKS documentation.
 ## ClinVar Concepts
 
 **ClinVar**
-:   NCBI database of clinically relevant variant submissions and aggregate classifications.
+:   NCBI database of variant submissions and aggregate classifications from clinical, research, and community sources.
 
 **SCV** (Submitted Clinical Variant)
-:   Individual submission from a laboratory or organization reporting their clinical interpretation of a variant. Each SCV contains one classification for one variant and condition combination.
+:   Individual submission from a laboratory, research group, or other organization reporting their interpretation of a variant. Each SCV contains one classification for one variant and condition combination.
 
 **VCV** (Variant-level Clinical Variant)
 :   Aggregate classification combining all SCV submissions for the same variant across all conditions. Represents the variant-level summary.
@@ -82,10 +82,10 @@ Key terms, acronyms, and concepts used throughout the ClinVar-GKS documentation.
 ## Data Model
 
 **Statement** (VA-Spec)
-:   A complete clinical assertion containing classification, proposition, evidence, contributions, and metadata. Both SCV and VCV records are Statements.
+:   A complete assertion containing classification, proposition, evidence, contributions, and metadata. Both SCV and VCV records are Statements.
 
 **Proposition** (VA-Spec)
-:   The core clinical claim being asserted. Contains a subject (variant), predicate (relationship), object (condition/therapy), and optional qualifiers.
+:   The core claim being asserted. Contains a subject (variant), predicate (relationship), object (condition/therapy), and optional qualifiers.
 
 **EvidenceLine** (VA-Spec)
 :   Links a proposition to evidence items with direction and strength assessments. SCV statements use `hasEvidenceLines`; VCV statements use nested `evidenceLines`.
@@ -103,7 +103,7 @@ Key terms, acronyms, and concepts used throughout the ClinVar-GKS documentation.
 :   Defining relationship between a categorical variant and its VRS representation. Types: DefiningAlleleConstraint, DefiningLocationConstraint, CopyChangeConstraint, CopyCountConstraint.
 
 **Extension**
-:   Name/value pair carrying metadata not part of core GA4GH specifications but essential for clinical interpretation. Present on statements, classifications, propositions, conditions, and categorical variants.
+:   Name/value pair carrying metadata not part of core GA4GH specifications but essential for interpreting the data. Present on statements, classifications, propositions, conditions, and categorical variants.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: ClinVar-GKS Documentation
+site_name: ClinVar-GKS
 site_description: ClinVar data transformation pipeline to GA4GH GKS format
 site_url: https://clingen-data-model.github.io/clinvar-gks/
 repo_url: https://github.com/clingen-data-model/clinvar-gks

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -53,56 +53,55 @@ markdown_extensions:
 
 nav:
   - Home: index.md
-  - Getting Started: getting-started.md
-  - Data Access: data-access/index.md
-  # --- Understanding the Data ---
-  - Understanding the Data:
+  # --- Data Guide: narrative topic pages ---
+  - Data Guide:
     - Output Format: output-reference/overview.md
-    - Data Model:
-      - output-reference/classes/index.md
-      - Variations:
-        - output-reference/classes/variations.md
-        - ClinvarCategoricalVariant: output-reference/classes/ClinvarCategoricalVariant.md
-        - ClinvarCanonicalAllele: output-reference/classes/ClinvarCanonicalAllele.md
-        - ClinvarCategoricalCnvChange: output-reference/classes/ClinvarCategoricalCnvChange.md
-        - ClinvarCategoricalCnvCount: output-reference/classes/ClinvarCategoricalCnvCount.md
-        - ClinvarNonConstrainedVariant: output-reference/classes/ClinvarNonConstrainedVariant.md
-        - HgvsListItem: output-reference/classes/HgvsListItem.md
-        - GeneListItem: output-reference/classes/GeneListItem.md
-      - Propositions:
-        - output-reference/classes/propositions.md
-        - ClinvarProposition: output-reference/classes/ClinvarProposition.md
-        - ClinvarRiskFactorProposition: output-reference/classes/ClinvarRiskFactorProposition.md
-        - ClinvarProtectiveProposition: output-reference/classes/ClinvarProtectiveProposition.md
-        - ClinvarDrugResponseProposition: output-reference/classes/ClinvarDrugResponseProposition.md
-        - ClinvarAffectsProposition: output-reference/classes/ClinvarAffectsProposition.md
-        - ClinvarAssociationProposition: output-reference/classes/ClinvarAssociationProposition.md
-        - ClinvarConfersSensitivityProposition: output-reference/classes/ClinvarConfersSensitivityProposition.md
-        - ClinvarOtherProposition: output-reference/classes/ClinvarOtherProposition.md
-        - ClinvarNotProvidedProposition: output-reference/classes/ClinvarNotProvidedProposition.md
-        - ClinvarConflictingDataFromSubmitterProposition: output-reference/classes/ClinvarConflictingDataFromSubmitterProposition.md
-      - Statements:
-        - output-reference/classes/statements.md
-        - ClinvarStatement: output-reference/classes/ClinvarStatement.md
-        - ClinvarScvStatement: output-reference/classes/ClinvarScvStatement.md
-        - ClinvarVcvStatement: output-reference/classes/ClinvarVcvStatement.md
-        - ClinvarRcvStatement: output-reference/classes/ClinvarRcvStatement.md
-        - SubmittedConditionMapping: output-reference/classes/SubmittedConditionMapping.md
-      - Evidence:
-        - output-reference/classes/evidence.md
-        - ClinvarSomaticEvidenceLine: output-reference/classes/ClinvarSomaticEvidenceLine.md
     - Variations: output-reference/cat-vrs.md
     - SCV Statements: output-reference/scv-statements.md
     - VCV Statements: output-reference/vcv-statements.md
     - RCV Statements: output-reference/rcv-statements.md
     - ID References: output-reference/id-references.md
+    - Examples: data-access/examples.md
+  # --- Data Model: class reference + profiles ---
+  - Data Model:
+    - output-reference/classes/index.md
+    - Variations:
+      - output-reference/classes/variations.md
+      - ClinvarCategoricalVariant: output-reference/classes/ClinvarCategoricalVariant.md
+      - ClinvarCanonicalAllele: output-reference/classes/ClinvarCanonicalAllele.md
+      - ClinvarCategoricalCnvChange: output-reference/classes/ClinvarCategoricalCnvChange.md
+      - ClinvarCategoricalCnvCount: output-reference/classes/ClinvarCategoricalCnvCount.md
+      - ClinvarNonConstrainedVariant: output-reference/classes/ClinvarNonConstrainedVariant.md
+      - HgvsListItem: output-reference/classes/HgvsListItem.md
+      - GeneListItem: output-reference/classes/GeneListItem.md
+    - Propositions:
+      - output-reference/classes/propositions.md
+      - ClinvarProposition: output-reference/classes/ClinvarProposition.md
+      - ClinvarRiskFactorProposition: output-reference/classes/ClinvarRiskFactorProposition.md
+      - ClinvarProtectiveProposition: output-reference/classes/ClinvarProtectiveProposition.md
+      - ClinvarDrugResponseProposition: output-reference/classes/ClinvarDrugResponseProposition.md
+      - ClinvarAffectsProposition: output-reference/classes/ClinvarAffectsProposition.md
+      - ClinvarAssociationProposition: output-reference/classes/ClinvarAssociationProposition.md
+      - ClinvarConfersSensitivityProposition: output-reference/classes/ClinvarConfersSensitivityProposition.md
+      - ClinvarOtherProposition: output-reference/classes/ClinvarOtherProposition.md
+      - ClinvarNotProvidedProposition: output-reference/classes/ClinvarNotProvidedProposition.md
+      - ClinvarConflictingDataFromSubmitterProposition: output-reference/classes/ClinvarConflictingDataFromSubmitterProposition.md
+    - Statements:
+      - output-reference/classes/statements.md
+      - ClinvarStatement: output-reference/classes/ClinvarStatement.md
+      - ClinvarScvStatement: output-reference/classes/ClinvarScvStatement.md
+      - ClinvarVcvStatement: output-reference/classes/ClinvarVcvStatement.md
+      - ClinvarRcvStatement: output-reference/classes/ClinvarRcvStatement.md
+      - SubmittedConditionMapping: output-reference/classes/SubmittedConditionMapping.md
+    - Evidence:
+      - output-reference/classes/evidence.md
+      - ClinvarSomaticEvidenceLine: output-reference/classes/ClinvarSomaticEvidenceLine.md
     - Profiles:
       - profiles/index.md
       - Statement Types: profiles/statement-types.md
       - Classifications: profiles/classifications.md
       - Propositions: profiles/propositions.md
       - Review Status: profiles/review-status.md
-    - Examples: data-access/examples.md
   # --- Pipeline & Technical ---
   - Pipeline:
     - pipeline/index.md


### PR DESCRIPTION
## Summary

- Consolidate Home, Getting Started, and Data Access into a single Home page to reduce tab sprawl
- Split "Understanding the Data" into two focused tabs: **Data Guide** (narrative topic pages) and **Data Model** (class reference + profiles)
- Expand extension documentation on each topic page (Variations, SCV/VCV/RCV Statements) with complete reference tables, custom type sub-sections, and proper `Extension` typing with `0..*` cardinality
- Pipeline extension pages now cross-reference the topic pages as the canonical schema reference

## Nav structure

```
Before: Home | Getting Started | Data Access | Understanding the Data | Pipeline | Reference | Drafts
After:  Home | Data Guide | Data Model | Pipeline | Reference | Drafts
```

## Test plan

- [x] `mkdocs build --strict` passes with no errors
- [ ] Visual review of nav tabs and extension table rendering in `mkdocs serve`
- [ ] Verify extension table anchor links jump correctly to custom type sub-sections
- [ ] Confirm pipeline extension pages link back to topic pages correctly