### PR TITLE
Standardise output table names to gks_dict_* convention

### DIFF
--- a/docs/pipeline/export.md
+++ b/docs/pipeline/export.md
@@ -32,15 +32,15 @@ The script exports the following tables:
 | `gks_dict_allele` | `allele-*.ndjson.gz` |
 | `gks_dict_gene` | `gene-*.ndjson.gz` |
 | `gks_dict_variation` | `variation-*.ndjson.gz` |
-| `gks_traits` | `condition-*.ndjson.gz` |
-| `gks_trait_sets` | `conditionSet-*.ndjson.gz` |
+| `gks_dict_condition` | `condition-*.ndjson.gz` |
+| `gks_dict_condition_set` | `conditionSet-*.ndjson.gz` |
 | `gks_dict_submitter` | `submitter-*.ndjson.gz` |
 | `gks_dict_proposition` | `proposition-*.ndjson.gz` |
 | `gks_dict_vcv_proposition` | `vcv_proposition-*.ndjson.gz` |
 | `gks_dict_rcv_proposition` | `rcv_proposition-*.ndjson.gz` |
-| `gks_scv_statement_pre` | `scv-*.ndjson.gz` |
-| `gks_vcv_statement_pre` | `vcv-*.ndjson.gz` |
-| `gks_rcv_statement_pre` | `rcv-*.ndjson.gz` |
+| `gks_dict_scv` | `scv-*.ndjson.gz` |
+| `gks_dict_vcv` | `vcv-*.ndjson.gz` |
+| `gks_dict_rcv` | `rcv-*.ndjson.gz` |
 
 BigQuery `EXTRACT` shards large tables across multiple files automatically. The assembly step recombines them.
 

--- a/docs/pipeline/index.md
+++ b/docs/pipeline/index.md
@@ -34,20 +34,20 @@ The pipeline executes in the following order. Each step is a BigQuery stored pro
                │
 ┌──────────────▼───────────────┐
 │ 5. SCV Statements            │  gks_scv_statement_proc
-│    Build SCV records,        │  → gks_scv_statement_pre table
+│    Build SCV records,        │  → gks_dict_scv table
 │    propositions & statements │
 └──────────────┬───────────────┘
                │
 ┌──────────────▼───────────────┐
 │ 6. VCV Statements            │  gks_vcv_proc +
 │    Aggregate SCVs into       │  gks_vcv_statement_proc
-│    variant-level statements  │  → gks_vcv_statement_pre table
+│    variant-level statements  │  → gks_dict_vcv table
 └──────────────┬───────────────┘
                │
 ┌──────────────▼───────────────┐
 │ 7. RCV Statements            │  gks_rcv_proc +
 │    Aggregate SCVs into       │  gks_rcv_statement_proc
-│    condition-level statements│  → gks_rcv_statement_pre table
+│    condition-level statements│  → gks_dict_rcv table
 └──────────────┬───────────────┘
                │
 ┌──────────────▼───────────────┐

--- a/docs/pipeline/rcv-statements/index.md
+++ b/docs/pipeline/rcv-statements/index.md
@@ -26,7 +26,7 @@ The pipeline is implemented across two stored procedures plus a JSON serializati
 ## Pipeline Flow
 
 ```text
-SCV Statements (gks_scv_statement_pre)
+SCV Statements (gks_dict_scv)
          |
          v
 +---------------------------------+
@@ -50,7 +50,7 @@ SCV Statements (gks_scv_statement_pre)
 +--------------+------------------+
                |
                v
-        gks_rcv_statement_pre
+        gks_dict_rcv
 ```
 
 ---

--- a/docs/pipeline/rcv-statements/rcv-proc.md
+++ b/docs/pipeline/rcv-statements/rcv-proc.md
@@ -146,7 +146,7 @@ Step-specific differences:
 
 ### Base Grouping PRE
 
-Inlines SCV evidence items from `gks_scv_statement_pre`. Evidence lines are rewritten to reference SCV IDs in `clinvar.submission:{scv_id}` format. The `classification`, `confidence`, `direction`, `strength`, and `proposition` fields are carried forward unchanged from the BASE.
+Inlines SCV evidence items from `gks_dict_scv`. Evidence lines are rewritten to reference SCV IDs in `clinvar.submission:{scv_id}` format. The `classification`, `confidence`, `direction`, `strength`, and `proposition` fields are carried forward unchanged from the BASE.
 
 **Output:** `temp_rcv_grouping_base_pre` <span class="role-badge badge-internal">Internal</span>
 
@@ -172,7 +172,7 @@ Inlines evidence items from either Tier Grouping PRE or Base Grouping PRE (using
 
 Selects all Aggregate Contribution PRE statements into the final output table.
 
-**Output:** `gks_rcv_statement_pre` -- the complete set of RCV statements ready for JSON serialization by `gks_json_proc`. <span class="role-badge badge-pipeline">Pipeline table</span>
+**Output:** `gks_dict_rcv` -- the complete set of RCV statements ready for JSON serialization by `gks_json_proc`. <span class="role-badge badge-pipeline">Pipeline table</span>
 
 ---
 
@@ -191,7 +191,7 @@ Selects all Aggregate Contribution PRE statements into the final output table.
 | `temp_rcv_grouping_base_pre` | `gks_rcv_statement_proc` | PRE statement structures with inlined SCV evidence | <span class="role-badge badge-internal">Internal</span> |
 | `temp_rcv_grouping_tier_pre` | `gks_rcv_statement_proc` | PRE statement structures with inlined Base Grouping evidence (somatic only) | <span class="role-badge badge-internal">Internal</span> |
 | `temp_rcv_agg_contribution_pre` | `gks_rcv_statement_proc` | PRE statement structures with inlined evidence for Aggregate Contribution | <span class="role-badge badge-internal">Internal</span> |
-| `gks_rcv_statement_pre` | `gks_rcv_statement_proc` | Final RCV statements from Aggregate Contribution PRE | <span class="role-badge badge-pipeline">Pipeline table</span> |
+| `gks_dict_rcv` | `gks_rcv_statement_proc` | Final RCV statements from Aggregate Contribution PRE | <span class="role-badge badge-pipeline">Pipeline table</span> |
 
 ---
 
@@ -208,7 +208,7 @@ Selects all Aggregate Contribution PRE statements into the final output table.
 
 - **Aggregation Tables**: `gks_rcv_grouping_base_agg`, `gks_rcv_grouping_tier_agg`, `gks_rcv_aggregate_contribution`
 - **Condition Tables**: `rcv_mapping`, `gks_scv_condition_sets`
-- **Statement Tables**: `gks_scv_statement_pre`
+- **Statement Tables**: `gks_dict_scv`
 - **Source Tables**: `scv_summary`
 - **Lookup Tables**: `clinvar_statement_categories`, `clinvar_proposition_types`, `submission_level`, `clinvar_clinsig_types`
 - **UDFs**: `clinvar_ingest.schema_on`, `clinvar_ingest.cleanup_temp_tables`

--- a/docs/pipeline/scv-statements/final-statements.md
+++ b/docs/pipeline/scv-statements/final-statements.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Step 7 of `gks_scv_statement_proc` performs the final assembly of complete VA-Spec Statement records into `gks_scv_statement_pre`. This step joins all previously built components -- SCV records, propositions, conditions, citations, and assertion methods -- into the output structure consumed by VCV procedures and the JSON export pipeline.
+Step 7 of `gks_scv_statement_proc` performs the final assembly of complete VA-Spec Statement records into `gks_dict_scv`. This step joins all previously built components -- SCV records, propositions, conditions, citations, and assertion methods -- into the output structure consumed by VCV procedures and the JSON export pipeline.
 
 ---
 
@@ -89,7 +89,7 @@ For somatic clinical impact assertions, the `hasEvidenceLines` field contains ev
 
 ## Output
 
-**`gks_scv_statement_pre`** -- one row per SCV with the complete VA-Spec Statement record. <span class="role-badge badge-pipeline">Pipeline table</span>
+**`gks_dict_scv`** -- one row per SCV with the complete VA-Spec Statement record. <span class="role-badge badge-pipeline">Pipeline table</span>
 
 Consumed by `gks_vcv_proc`, `gks_vcv_statement_proc`, and `gks_json_proc` for VCV aggregation and JSON export.
 

--- a/docs/pipeline/scv-statements/index.md
+++ b/docs/pipeline/scv-statements/index.md
@@ -53,11 +53,11 @@ Builds somatic target propositions for clinical impact assertions (prognostic, d
 
 **Output:** `temp_gks_scv_target_proposition` — one row per somatic SCV with target proposition. <span class="role-badge badge-internal">Internal</span>
 
-### Step 7: Build `gks_scv_statement_pre`
+### Step 7: Build `gks_dict_scv`
 
 Final assembly of VA-Spec Statement records. Joins SCV records with propositions, conditions, citations, and assertion methods. Builds the classification struct with description extension, contributions array, extensions array (clinvarScvId, clinvarScvVersion, clinvarScvReviewStatus, submittedScvClassification, submittedScvLocalKey, submissionLevel), and somatic evidence lines.
 
-**Output:** `gks_scv_statement_pre` — one row per SCV with complete VA-Spec Statement record. <span class="role-badge badge-pipeline">Pipeline table</span>
+**Output:** `gks_dict_scv` — one row per SCV with complete VA-Spec Statement record. <span class="role-badge badge-pipeline">Pipeline table</span>
 
 ---
 
@@ -71,7 +71,7 @@ Final assembly of VA-Spec Statement records. Joins SCV records with propositions
 | `temp_penetrance_qualifiers` | Penetrance qualifiers for low-penetrance and risk alleles | <span class="role-badge badge-internal">Internal</span> |
 | `temp_gks_scv_proposition` | Assembled primary propositions with qualifiers and conditions | <span class="role-badge badge-internal">Internal</span> |
 | `temp_gks_scv_target_proposition` | Somatic target propositions for clinical impact assertions | <span class="role-badge badge-internal">Internal</span> |
-| `gks_scv_statement_pre` | Complete VA-Spec Statement records for all SCVs | <span class="role-badge badge-pipeline">Pipeline table</span> |
+| `gks_dict_scv` | Complete VA-Spec Statement records for all SCVs | <span class="role-badge badge-pipeline">Pipeline table</span> |
 
 ---
 

--- a/docs/pipeline/vcv-statements/index.md
+++ b/docs/pipeline/vcv-statements/index.md
@@ -23,7 +23,7 @@ The pipeline is implemented across two stored procedures plus a JSON serializati
 ## Pipeline Flow
 
 ```text
-SCV Statements (gks_scv_statement_pre)
+SCV Statements (gks_dict_scv)
          │
          ▼
 ┌──────────────────────────────────┐
@@ -42,7 +42,7 @@ SCV Statements (gks_scv_statement_pre)
 └───────────────┬──────────────────┘
                 │
                 ▼
-         gks_vcv_statement_pre
+         gks_dict_vcv
 ```
 
 ---

--- a/docs/pipeline/vcv-statements/vcv-proc.md
+++ b/docs/pipeline/vcv-statements/vcv-proc.md
@@ -156,7 +156,7 @@ Inlines evidence items from either Grouping Tier PRE or Grouping Base PRE (using
 
 Selects all Aggregate Contribution PRE statements into the final output table.
 
-**Output:** `gks_vcv_statement_pre` -- the complete set of VCV statements ready for JSON serialization by `gks_json_proc`. <span class="role-badge badge-pipeline">Pipeline table</span>
+**Output:** `gks_dict_vcv` -- the complete set of VCV statements ready for JSON serialization by `gks_json_proc`. <span class="role-badge badge-pipeline">Pipeline table</span>
 
 ---
 
@@ -174,7 +174,7 @@ Selects all Aggregate Contribution PRE statements into the final output table.
 | `temp_vcv_grouping_base_pre` | `gks_vcv_statement_proc` | PRE statement structures with inlined SCV evidence | <span class="role-badge badge-internal">Internal</span> |
 | `temp_vcv_grouping_tier_pre` | `gks_vcv_statement_proc` | PRE statement structures with inlined Base Grouping evidence | <span class="role-badge badge-internal">Internal</span> |
 | `temp_vcv_agg_contribution_pre` | `gks_vcv_statement_proc` | PRE statement structures with inlined Tier/Base Grouping evidence | <span class="role-badge badge-internal">Internal</span> |
-| `gks_vcv_statement_pre` | `gks_vcv_statement_proc` | Final VCV statements from Aggregate Contribution PRE | <span class="role-badge badge-pipeline">Pipeline table</span> |
+| `gks_dict_vcv` | `gks_vcv_statement_proc` | Final VCV statements from Aggregate Contribution PRE | <span class="role-badge badge-pipeline">Pipeline table</span> |
 
 ---
 
@@ -190,7 +190,7 @@ Selects all Aggregate Contribution PRE statements into the final output table.
 ### gks_vcv_statement_proc
 
 - **Aggregation Tables**: `gks_vcv_grouping_base_agg`, `gks_vcv_grouping_tier_agg`, `gks_vcv_aggregate_contribution`
-- **Statement Tables**: `gks_scv_statement_pre`, `gks_scv_condition_sets`
+- **Statement Tables**: `gks_dict_scv`, `gks_scv_condition_sets`
 - **Source Tables**: `scv_summary`
 - **Lookup Tables**: `clinvar_statement_categories`, `clinvar_proposition_types`, `submission_level`, `clinvar_clinsig_types`
 - **UDFs**: `clinvar_ingest.schema_on`, `clinvar_ingest.cleanup_temp_tables`

--- a/src/procedures/gks-json-proc.sql
+++ b/src/procedures/gks-json-proc.sql
@@ -54,7 +54,7 @@ BEGIN
               TO_JSON(tv),
             remove_empty => TRUE
             ) AS rec
-          FROM `{S}.gks_scv_statement_pre` AS tv
+          FROM `{S}.gks_dict_scv` AS tv
         )
         SELECT
           json_draft.id,
@@ -80,7 +80,7 @@ BEGIN
               TO_JSON(tv),
             remove_empty => TRUE
             ) AS rec
-          FROM `{S}.gks_vcv_statement_pre` AS tv
+          FROM `{S}.gks_dict_vcv` AS tv
         )
         SELECT
           json_draft.id,
@@ -106,7 +106,7 @@ BEGIN
               TO_JSON(tv),
             remove_empty => TRUE
             ) AS rec
-          FROM `{S}.gks_rcv_statement_pre` AS tv
+          FROM `{S}.gks_dict_rcv` AS tv
         )
         SELECT
           json_draft.id,

--- a/src/procedures/gks-rcv-statement-proc.sql
+++ b/src/procedures/gks-rcv-statement-proc.sql
@@ -544,7 +544,7 @@ BEGIN
     -- FINAL: RCV statement pre (all Aggregate Contribution statements)
     -------------------------------------------------------------------------
     SET query_rcv_pre = REPLACE("""
-      CREATE OR REPLACE TABLE `{S}.gks_rcv_statement_pre` AS
+      CREATE OR REPLACE TABLE `{S}.gks_dict_rcv` AS
       SELECT * FROM `{P}.temp_rcv_agg_contribution_pre`
     """, '{S}', rec.schema_name);
     SET query_rcv_pre = REPLACE(query_rcv_pre, '{P}', IF(debug, rec.schema_name, '_SESSION'));

--- a/src/procedures/gks-scv-condition-proc.sql
+++ b/src/procedures/gks-scv-condition-proc.sql
@@ -1,11 +1,11 @@
 
 CREATE OR REPLACE PROCEDURE `clinvar_ingest.gks_scv_condition_proc`(on_date DATE, debug BOOL)
 BEGIN
-  DECLARE query_gks_traits STRING;
+  DECLARE query_gks_dict_condition STRING;
   DECLARE temp_rcv_mapping_traits_query STRING;
   DECLARE temp_gks_scv_trait_sets_query STRING;
   DECLARE temp_all_rcv_traits_query STRING;
-  DECLARE query_gks_trait_sets STRING;
+  DECLARE query_gks_dict_condition_set STRING;
   DECLARE temp_scv_trait_name_xrefs_query STRING;
   DECLARE temp_scv_trait_mappings_query STRING;  
   DECLARE temp_scv_trait_assignment_stage1_query STRING;
@@ -34,12 +34,12 @@ BEGIN
     END IF;
 
     -- -----------------------------------------------------------------------
-    -- STEP 1: Create gks_traits (canonical trait representations)
+    -- STEP 1: Create gks_dict_condition (canonical trait representations)
     -- All traits with clinvar.trait:{id} identifiers, with primaryCoding,
     -- mappings (deduplicated by code+system), and aliases extension.
     -- -----------------------------------------------------------------------
-    SET query_gks_traits = REPLACE("""
-      CREATE OR REPLACE TABLE `{S}.gks_traits` AS
+    SET query_gks_dict_condition = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_condition` AS
       WITH traits AS (
         select distinct
           t.id,
@@ -127,7 +127,7 @@ BEGIN
         t.type,
         t.name
     """, '{S}', rec.schema_name);
-    EXECUTE IMMEDIATE query_gks_traits;
+    EXECUTE IMMEDIATE query_gks_dict_condition;
 
     -- -----------------------------------------------------------------------
     -- STEP 2: Create temp_rcv_mapping_traits
@@ -280,12 +280,12 @@ BEGIN
     EXECUTE IMMEDIATE temp_all_rcv_traits_query;
 
     -- -----------------------------------------------------------------------
-    -- STEP 5: Create gks_trait_sets (persistent baseline traitset representations)
+    -- STEP 5: Create gks_dict_condition_set (persistent baseline traitset representations)
     -- Unique trait sets with clinvar.traitset:{id} identifiers, referencing
     -- member traits via #/traits/clinvar.trait:{trait_id}.
     -- -----------------------------------------------------------------------
-    SET query_gks_trait_sets = REPLACE("""
-      CREATE OR REPLACE TABLE `{S}.gks_trait_sets` AS
+    SET query_gks_dict_condition_set = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_condition_set` AS
       WITH trait_set_traits AS (
         SELECT DISTINCT
           art.rcv_trait_set_id,
@@ -317,8 +317,8 @@ BEGIN
         ON art.rcv_trait_set_id = tsi.rcv_trait_set_id AND art.rcv_trait_id = tst.rcv_trait_id
       GROUP BY tsi.rcv_trait_set_id, tsi.rcv_trait_set_type
     """, '{S}', rec.schema_name);
-    SET query_gks_trait_sets = REPLACE(query_gks_trait_sets, '{P}', IF(debug, rec.schema_name, '_SESSION'));
-    EXECUTE IMMEDIATE query_gks_trait_sets;
+    SET query_gks_dict_condition_set = REPLACE(query_gks_dict_condition_set, '{P}', IF(debug, rec.schema_name, '_SESSION'));
+    EXECUTE IMMEDIATE query_gks_dict_condition_set;
   
     -- -----------------------------------------------------------------------
     -- STEP 6: Create temp_scv_trait_name_xrefs
@@ -390,7 +390,7 @@ BEGIN
             stx.id
         )
         -- this statement is responsible for preserving the submitted xref id and db values as well as normalizing
-        --  them so they best match the intended values and subsequently give the best opportunity to match with the gks_traits.xrefs.
+        --  them so they best match the intended values and subsequently give the best opportunity to match with the gks_dict_condition.xrefs.
         SELECT
           stx.id as cat_id,
           stx.type as cat_type,
@@ -639,7 +639,7 @@ BEGIN
             gt.primaryCoding.code AS mapped_medgen_id,
             IF(gt.trait_id IS NOT NULL, 'trait-mapping-then-submitted-medgen-id', NULL) AS mapped_resolution_type
           FROM medgen_scv_traits mst
-          LEFT JOIN `{S}.gks_traits` gt
+          LEFT JOIN `{S}.gks_dict_condition` gt
             ON gt.primaryCoding.code = mst.lookup_medgen_id
         ),
         -- Pivot each SCV trait's match key into a row with priority
@@ -924,7 +924,7 @@ BEGIN
             ) AS condition_struct
           FROM 
             {P}.temp_scv_trait_assignment_stage2 scm
-          LEFT JOIN `{S}.gks_trait_sets` 
+          LEFT JOIN `{S}.gks_dict_condition_set` 
             ts ON FORMAT('clinvar.traitset:%s', scm.rcv_trait_set_id) = ts.id
         ),
         multi_sets AS (

--- a/src/procedures/gks-scv-statement-proc.sql
+++ b/src/procedures/gks-scv-statement-proc.sql
@@ -633,7 +633,7 @@ BEGIN
     -- Step 8: Create statement SCV pre table (simple join, no UNNEST)
     ---------------------------------------------------------------------------
     SET query_statement_scv_pre = REPLACE("""
-      CREATE OR REPLACE TABLE `{S}.gks_scv_statement_pre`
+      CREATE OR REPLACE TABLE `{S}.gks_dict_scv`
       as
       WITH null_templates AS (
         SELECT

--- a/src/procedures/gks-vcv-statement-proc.sql
+++ b/src/procedures/gks-vcv-statement-proc.sql
@@ -507,7 +507,7 @@ BEGIN
     -- FINAL: VCV statement pre (all Aggregate Contribution statements)
     -------------------------------------------------------------------------
     SET query_vcv_pre = REPLACE("""
-      CREATE OR REPLACE TABLE `{S}.gks_vcv_statement_pre` AS
+      CREATE OR REPLACE TABLE `{S}.gks_dict_vcv` AS
       SELECT * FROM `{P}.temp_vcv_agg_contribution_pre`
     """, '{S}', rec.schema_name);
     SET query_vcv_pre = REPLACE(query_vcv_pre, '{P}', IF(debug, rec.schema_name, '_SESSION'));

--- a/src/scripts/export-gks-dicts.sh
+++ b/src/scripts/export-gks-dicts.sh
@@ -33,8 +33,8 @@ extract gks_dict_gene gene.ndjson.gz
 extract gks_dict_variation variation.ndjson.gz
 
 # Condition dictionaries (from gks_scv_condition_proc)
-extract gks_traits condition.ndjson.gz
-extract gks_trait_sets conditionSet.ndjson.gz
+extract gks_dict_condition condition.ndjson.gz
+extract gks_dict_condition_set conditionSet.ndjson.gz
 
 # SCV dictionaries (from gks_scv_statement_proc)
 extract gks_dict_submitter submitter.ndjson.gz
@@ -45,8 +45,8 @@ extract gks_dict_vcv_proposition vcv_proposition.ndjson.gz
 extract gks_dict_rcv_proposition rcv_proposition.ndjson.gz
 
 # Statement outputs
-extract gks_scv_statement_pre scv.ndjson.gz
-extract gks_vcv_statement_pre vcv.ndjson.gz
-extract gks_rcv_statement_pre rcv.ndjson.gz
+extract gks_dict_scv scv.ndjson.gz
+extract gks_dict_vcv vcv.ndjson.gz
+extract gks_dict_rcv rcv.ndjson.gz
 
 echo "Done. Files exported to ${GCS_PATH}/"


### PR DESCRIPTION
## Summary
- Renames all output tables to consistent `gks_dict_<section>` nomenclature
- `gks_traits` → `gks_dict_condition`
- `gks_trait_sets` → `gks_dict_condition_set`
- `gks_scv_statement_pre` → `gks_dict_scv`
- `gks_vcv_statement_pre` → `gks_dict_vcv`
- `gks_rcv_statement_pre` → `gks_dict_rcv`
- Updated across 5 SQL procedures, export script, and 8 documentation files

## Test plan
- [ ] Deploy updated SQL procedures to BigQuery
- [ ] Run full pipeline on a test dataset and verify new table names are created
- [ ] Run `export-gks-dicts.sh` and verify NDJSON export uses new table names
- [ ] Verify `mkdocs build --strict` passes (confirmed locally)