### PR TITLE
Split allele dict by VRS type, rename Non-Constrained to Undefined

### DIFF
--- a/docs/output-reference/cat-vrs.md
+++ b/docs/output-reference/cat-vrs.md
@@ -122,7 +122,7 @@ See [Categorical Variant Extensions (Pipeline)](../pipeline/cat-vrs/catvar-exten
 
 | Extension Name | Value Type | Description |
 |---|---|---|
-| `categoricalVariationType` | `string` | The Cat-VRS category assigned to this variation: `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount`, or `Non-Constrained`. Determines which constraint types are generated. |
+| `categoricalVariationType` | `string` | The Cat-VRS category assigned to this variation: `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount`, or `Undefined`. Determines which constraint types are generated. |
 | `definingVrsVariationType` | `string` | The VRS class assigned during variation identity processing (e.g., `Allele`, `CopyNumberChange`, `CopyNumberCount`, `Not Available`). Reflects the upstream classification used to route the variant through VRS processing. |
 | `clinvarVariationType` | `string` | The variation type as reported by ClinVar (e.g., `Deletion`, `single nucleotide variant`, `Duplication`, `Indel`). Present when ClinVar provides a variation type. |
 | `clinvarSubclassType` | `string` | The variation subclass as reported by ClinVar (e.g., `SimpleAllele`, `Haplotype`, `CompoundHeterozygote`). Present when ClinVar provides a subclass type. |

--- a/docs/output-reference/classes/variations.md
+++ b/docs/output-reference/classes/variations.md
@@ -21,7 +21,7 @@ All ClinVar variant types carry a shared set of extensions that provide ClinVar 
 | --- | --- |
 | `clinvarHgvsList` | Complete list of HGVS expressions — nucleotide and protein forms, MANE select/plus designations, and molecular consequences (SO terms). Each entry is an [HgvsListItem](HgvsListItem.md). |
 | `clinvarGeneList` | Gene associations including Entrez gene ID, HGNC ID, symbol, and relationship type. Each entry is a [GeneListItem](GeneListItem.md). |
-| `categoricalVariationType` | The Cat-VRS category assigned: `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount`, or `Non-Constrained`. |
+| `categoricalVariationType` | The Cat-VRS category assigned: `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount`, or `Undefined`. |
 | `definingVrsVariationType` | The VRS class from upstream processing: `Allele`, `CopyNumberChange`, `CopyNumberCount`, `Haplotype`, `Unknown`, or `Not Available`. |
 | `clinvarVariationType` | The variation type as reported by ClinVar (e.g., `Deletion`, `single nucleotide variant`, `Duplication`). |
 | `clinvarSubclassType` | The ClinVar subclass: `SimpleAllele`, `Haplotype`, or `Genotype`. |

--- a/docs/pipeline/cat-vrs/catvar-extensions.md
+++ b/docs/pipeline/cat-vrs/catvar-extensions.md
@@ -19,7 +19,7 @@ Extensions on the top-level `CategoricalVariant` record.
 
 | Extension | Type | Description |
 |---|---|---|
-| `categoricalVariationType` | string | The Cat-VRS category assigned to this variation: `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount`, or `Non-Constrained`. Determines which constraint types are generated. |
+| `categoricalVariationType` | string | The Cat-VRS category assigned to this variation: `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount`, or `Undefined`. Determines which constraint types are generated. |
 | `definingVrsVariationType` | string | The VRS class assigned during variation identity processing (e.g., `Allele`, `CopyNumberChange`, `CopyNumberCount`, `Not Available`). Reflects the upstream classification used to route the variant through VRS processing. |
 | `clinvarVariationType` | string | The variation type as reported by ClinVar (e.g., `Deletion`, `single nucleotide variant`, `Duplication`, `Indel`). Present when ClinVar provides a variation type. |
 | `clinvarSubclassType` | string | The variation subclass as reported by ClinVar (e.g., `SimpleAllele`, `Haplotype`, `CompoundHeterozygote`). Present when ClinVar provides a subclass type. |
@@ -92,7 +92,7 @@ When VRS processing issues are present, the error extensions appear alongside th
 
 ```json
 [
-  { "name": "categoricalVariationType", "value": "Non-Constrained" },
+  { "name": "categoricalVariationType", "value": "Undefined" },
   { "name": "definingVrsVariationType", "value": "Not Available" },
   { "name": "clinvarVariationType", "value": "Microsatellite" },
   { "name": "clinvarSubclassType", "value": "SimpleAllele" },

--- a/docs/pipeline/cat-vrs/index.md
+++ b/docs/pipeline/cat-vrs/index.md
@@ -56,7 +56,7 @@ Joins VRS output with expressions and sequence locations to build contextual var
 | `Allele` | `CanonicalAllele` |
 | `CopyNumberChange` | `CategoricalCnvChange` |
 | `CopyNumberCount` | `CategoricalCnvCount` |
-| Other | `Non-Constrained` |
+| Other | `Undefined` |
 
 **Output:** `temp_ctxvar` — one row per distinct contextual variant. <span class="role-badge badge-internal">Internal</span>
 

--- a/schema/clinvar-gks/clinvar-variant-source.yaml
+++ b/schema/clinvar-gks/clinvar-variant-source.yaml
@@ -154,7 +154,7 @@ $defs:
   ExtensionCategoricalVariationType:
     description: >-
       The Cat-VRS category assigned to this variation: `CanonicalAllele`, `CategoricalCnvChange`, 
-      `CategoricalCnvCount`, or `Non-Constrained`. Determines which constraint types are generated.
+      `CategoricalCnvCount`, or `Undefined`. Determines which constraint types are generated.
     protectedClassOf: ClinvarCategoricalVariant
     type: object
     maturity: draft
@@ -170,10 +170,10 @@ $defs:
           - "CanonicalAllele"
           - "CategoricalCnvChange"
           - "CategoricalCnvCount"
-          - "Non-Constrained"
+          - "Undefined"
         description: >-
           The type of categorical variant. It must be one of the following:
-          `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount`, or `Non-Constrained`.
+          `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount`, or `Undefined`.
 
   ExtensionDefiningVrsVariationType:
     description: >-

--- a/schema/clinvar-gks/json/ClinvarCategoricalVariant
+++ b/schema/clinvar-gks/json/ClinvarCategoricalVariant
@@ -117,7 +117,7 @@
          "additionalProperties": false
       },
       "ExtensionCategoricalVariationType": {
-         "description": "The Cat-VRS category assigned to this variation: `CanonicalAllele`, `CategoricalCnvChange`,  `CategoricalCnvCount`, or `Non-Constrained`. Determines which constraint types are generated.",
+         "description": "The Cat-VRS category assigned to this variation: `CanonicalAllele`, `CategoricalCnvChange`,  `CategoricalCnvCount`, or `Undefined`. Determines which constraint types are generated.",
          "protectedClassOf": "ClinvarCategoricalVariant",
          "type": "object",
          "maturity": "draft",
@@ -133,9 +133,9 @@
                   "CanonicalAllele",
                   "CategoricalCnvChange",
                   "CategoricalCnvCount",
-                  "Non-Constrained"
+                  "Undefined"
                ],
-               "description": "The type of categorical variant. It must be one of the following: `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount`, or `Non-Constrained`."
+               "description": "The type of categorical variant. It must be one of the following: `CanonicalAllele`, `CategoricalCnvChange`, `CategoricalCnvCount`, or `Undefined`."
             }
          },
          "required": [],

--- a/src/procedures/gks-catvar-proc.sql
+++ b/src/procedures/gks-catvar-proc.sql
@@ -5,6 +5,8 @@ BEGIN
   DECLARE dict_seqref_query STRING;
   DECLARE dict_location_query STRING;
   DECLARE dict_allele_query STRING;
+  DECLARE dict_copy_number_count_query STRING;
+  DECLARE dict_copy_number_change_query STRING;
   DECLARE temp_ctxvar_expr_query STRING;
   DECLARE temp_ctxvar_query STRING;
   DECLARE temp_catvar_ext_query STRING;
@@ -279,7 +281,7 @@ BEGIN
     EXECUTE IMMEDIATE temp_ctxvar_expr_query;
 
     -------------------------------------------------------------------------
-    -- Step 2b: Dictionary table - alleles (global, keyed by VRS allele id)
+    -- Step 2b: Dictionary table - alleles (Allele type only)
     -- Uses temp_ctxvar_expression for full expression set (spdi + hgvs + gnomad)
     -------------------------------------------------------------------------
     SET dict_allele_query = REPLACE("""
@@ -291,6 +293,7 @@ BEGIN
           vrs.in.variation_id
         FROM `{S}.gks_vrs` vrs
         WHERE vrs.out.id IS NOT NULL
+          AND vrs.out.type = 'Allele'
       )
       SELECT
         vrs.id as key,
@@ -300,8 +303,6 @@ BEGIN
           vrs.digest,
           exp.name,
           vrs.state,
-          vrs.copies,
-          vrs.copyChange,
           exp.expressions,
           FORMAT('#/location/%s', vrs.location.id) as location
         )), remove_empty => TRUE) as value
@@ -309,12 +310,61 @@ BEGIN
         SELECT DISTINCT out.*
         FROM `{S}.gks_vrs`
         WHERE out.id IS NOT NULL
+          AND out.type = 'Allele'
       ) vrs
       LEFT JOIN allele_to_variation atv ON atv.allele_id = vrs.id
       LEFT JOIN {P}.temp_ctxvar_expression exp ON exp.variation_id = atv.variation_id
     """, '{S}', rec.schema_name);
     SET dict_allele_query = REPLACE(dict_allele_query, '{P}', IF(debug, rec.schema_name, '_SESSION'));
     EXECUTE IMMEDIATE dict_allele_query;
+
+    -------------------------------------------------------------------------
+    -- Step 2c: Dictionary table - copy number counts (CopyNumberCount type only)
+    -------------------------------------------------------------------------
+    SET dict_copy_number_count_query = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_copy_number_count`
+      AS
+      SELECT
+        vrs.id as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          vrs.id,
+          vrs.type,
+          vrs.digest,
+          vrs.copies,
+          FORMAT('#/location/%s', vrs.location.id) as location
+        )), remove_empty => TRUE) as value
+      FROM (
+        SELECT DISTINCT out.*
+        FROM `{S}.gks_vrs`
+        WHERE out.id IS NOT NULL
+          AND out.type = 'CopyNumberCount'
+      ) vrs
+    """, '{S}', rec.schema_name);
+    EXECUTE IMMEDIATE dict_copy_number_count_query;
+
+    -------------------------------------------------------------------------
+    -- Step 2d: Dictionary table - copy number changes (CopyNumberChange type only)
+    -------------------------------------------------------------------------
+    SET dict_copy_number_change_query = REPLACE("""
+      CREATE OR REPLACE TABLE `{S}.gks_dict_copy_number_change`
+      AS
+      SELECT
+        vrs.id as key,
+        JSON_STRIP_NULLS(TO_JSON(STRUCT(
+          vrs.id,
+          vrs.type,
+          vrs.digest,
+          vrs.copyChange,
+          FORMAT('#/location/%s', vrs.location.id) as location
+        )), remove_empty => TRUE) as value
+      FROM (
+        SELECT DISTINCT out.*
+        FROM `{S}.gks_vrs`
+        WHERE out.id IS NOT NULL
+          AND out.type = 'CopyNumberChange'
+      ) vrs
+    """, '{S}', rec.schema_name);
+    EXECUTE IMMEDIATE dict_copy_number_change_query;
 
     -------------------------------------------------------------------------
     -- Step 3: Contextual variants with VRS type mapping
@@ -331,7 +381,7 @@ BEGIN
           WHEN 'Allele' THEN 'CanonicalAllele'
           WHEN 'CopyNumberChange' THEN 'CategoricalCnvChange'
           WHEN 'CopyNumberCount' THEN 'CategoricalCnvCount'
-          ELSE 'Non-Constrained'
+          ELSE 'Undefined'
           END as catvar_type,
           vrs.in.name,
           vrs.out.*


### PR DESCRIPTION
## Summary
- Splits `gks_dict_allele` into three type-specific dictionary tables: `gks_dict_allele` (Allele only), `gks_dict_copy_number_count` (CopyNumberCount), and `gks_dict_copy_number_change` (CopyNumberChange)
- Each table carries only the fields relevant to its VRS type (e.g., `copies` for CopyNumberCount, `copyChange` for CopyNumberChange)
- Renames the `categoricalVariationType` value `Non-Constrained` to `Undefined` across the SQL procedure, documentation, and schema files

## Test plan
- [ ] Run `CALL clinvar_ingest.gks_catvar_proc('2026-04-26', false);`
- [ ] Verify `gks_dict_allele` contains only rows with `type = 'Allele'` and no `copies`/`copyChange` fields
- [ ] Verify `gks_dict_copy_number_count` exists with `copies` field
- [ ] Verify `gks_dict_copy_number_change` exists with `copyChange` field
- [ ] Verify no rows contain `Non-Constrained` in the variation table's `categoricalVariationType` extension