### PR TITLE
Fix variation members FK to route by VRS type

### DIFF
--- a/src/procedures/gks-catvar-proc.sql
+++ b/src/procedures/gks-catvar-proc.sql
@@ -840,7 +840,12 @@ BEGIN
         cv.type,
         cv.name,
         cvc.constraints,
-        IF(cv.vrs_allele_id IS NOT NULL, [FORMAT('#/allele/%s', cv.vrs_allele_id)], []) as members,
+        CASE cv.catvar_type
+          WHEN 'CanonicalAllele' THEN [FORMAT('#/allele/%s', cv.vrs_allele_id)]
+          WHEN 'CategoricalCnvCount' THEN [FORMAT('#/copyNumberCount/%s', cv.vrs_allele_id)]
+          WHEN 'CategoricalCnvChange' THEN [FORMAT('#/copyNumberChange/%s', cv.vrs_allele_id)]
+          ELSE []
+        END as members,
         cvext.extensions,
         vm.mappings
       FROM catvar cv


### PR DESCRIPTION
## Summary
- Routes the `members` array FK in `gks_dict_variation` to the correct section based on categorical variant type
- `CanonicalAllele` → `#/allele/`, `CategoricalCnvCount` → `#/copyNumberCount/`, `CategoricalCnvChange` → `#/copyNumberChange/`
- Previously all members pointed to `#/allele/` regardless of VRS type, which would produce broken FKs for CNV variants after the allele table split (PR #44)

## Test plan
- [ ] Run `CALL clinvar_ingest.gks_catvar_proc('2026-04-26', false);`
- [ ] Verify `gks_dict_variation` members for a CopyNumberCount variation points to `#/copyNumberCount/...`
- [ ] Verify `gks_dict_variation` members for a CopyNumberChange variation points to `#/copyNumberChange/...`
- [ ] Verify `gks_dict_variation` members for an Allele variation still points to `#/allele/...`