### PR TITLE
Promote condition aliases from extension to top-level field

### DIFF
--- a/src/procedures/gks-scv-condition-proc.sql
+++ b/src/procedures/gks-scv-condition-proc.sql
@@ -91,6 +91,9 @@ BEGIN
         t.id as trait_id,
         t.type as conceptType,
         t.name,
+        ANY_VALUE(
+          IF(ARRAY_LENGTH(t.synonyms) > 0, t.synonyms, null)
+        ) as aliases,
         ARRAY_AGG(
           IF(
             tx.mapping.system = 'medgen',
@@ -106,18 +109,7 @@ BEGIN
             null
           )
           IGNORE NULLS
-        ) as mappings,
-        -- Use ANY_VALUE because we cannot GROUP BY the synonyms array
-        ANY_VALUE(
-          IF(
-            ARRAY_LENGTH(t.synonyms) > 0, 
-            [STRUCT(
-              'aliases' AS name,
-              t.synonyms AS value_array_string
-            )],
-            NULL 
-          )
-        ) AS extensions
+        ) as mappings
       FROM traits t
       LEFT JOIN trait_xrefs tx
       ON


### PR DESCRIPTION
## Summary
- Promotes `synonyms` from the `aliases` extension wrapper to a top-level `aliases` array on the condition dict (`gks_traits`)
- Removes the `extensions` column since it only contained the aliases entry
- Aligns condition output with the MappableConcept pattern: `id, conceptType, name, aliases, primaryCoding, mappings`

## Test plan
- [ ] Run `CALL clinvar_ingest.gks_scv_condition_proc('2026-04-26', false);`
- [ ] Verify `gks_traits` records have a top-level `aliases` array (not wrapped in extensions)
- [ ] Verify `extensions` column no longer exists
- [ ] Verify conditions with synonyms have them in the `aliases` field
- [ ] Verify conditions without synonyms have `aliases` as null