### PR TITLE
Rename condition_refs to concepts in conditionSet

### DIFF
--- a/src/procedures/gks-scv-condition-proc.sql
+++ b/src/procedures/gks-scv-condition-proc.sql
@@ -304,7 +304,7 @@ BEGIN
         ARRAY_AGG(
           FORMAT('#/condition/clinvar.trait:%s', tst.rcv_trait_id)
           ORDER BY tst.rcv_trait_id
-        ) AS condition_refs,
+        ) AS concepts,
         IF(
           ANY_VALUE(art.rcv_trait_relationship_type) IN ('Finding member','co-occurring condition'),
           'AND',
@@ -898,7 +898,7 @@ BEGIN
           SELECT 
             scm.scv_id,
             IF(scm.rcv_trait_count > 1, FORMAT('#/conditionSet/%s', ts.id), NULL) AS conditionSet,
-            IF(scm.rcv_trait_count = 1, ts.condition_refs[SAFE_OFFSET(0)], NULL) AS condition,
+            IF(scm.rcv_trait_count = 1, ts.concepts[SAFE_OFFSET(0)], NULL) AS condition,
             scm.multiple_condition_explanation,
             scm.cats_trait_count as scv_trait_count,
             STRUCT(


### PR DESCRIPTION
## Summary
- Renames `condition_refs` → `concepts` in `gks_trait_sets` (conditionSet dict)
- Updates the downstream reference in the condition assignment query (Step 10)
- `conceptSetType` and `membershipOperator` are already top-level fields — no changes needed there

## Test plan
- [ ] Run `CALL clinvar_ingest.gks_scv_condition_proc('2026-04-26', false);`
- [ ] Verify `gks_trait_sets` records have `concepts` instead of `condition_refs`
- [ ] Verify single-condition SCVs still resolve correctly (uses `ts.concepts[SAFE_OFFSET(0)]`)
- [ ] Run full pipeline through json proc to verify bundle output