### PR TITLE
Promote confidence from plain string to concept struct

### DIFF
--- a/src/procedures/gks-rcv-statement-proc.sql
+++ b/src/procedures/gks-rcv-statement-proc.sql
@@ -100,7 +100,7 @@ BEGIN
           ) AS name
         ) AS strength,
 
-        sl.label AS confidence,
+        STRUCT('Confidence' AS conceptType, sl.label AS name) AS confidence,
 
         -- classification: single MappableConcept for all submission levels
         STRUCT(
@@ -171,7 +171,7 @@ BEGIN
           END AS name
         ) AS strength,
 
-        sl.label AS confidence,
+        STRUCT('Confidence' AS conceptType, sl.label AS name) AS confidence,
 
         STRUCT(
           'Classification' AS conceptType,
@@ -253,7 +253,7 @@ BEGIN
           END AS name
         ) AS strength,
 
-        agg.contributing_submission_level_label AS confidence,
+        STRUCT('Confidence' AS conceptType, agg.contributing_submission_level_label AS name) AS confidence,
 
         STRUCT(
           'Classification' AS conceptType,

--- a/src/procedures/gks-scv-statement-proc.sql
+++ b/src/procedures/gks-scv-statement-proc.sql
@@ -700,7 +700,7 @@ BEGIN
           ) as primaryCoding
         ) as strength,
         scv.direction,
-        scv.submission_level_label as confidence,
+        STRUCT('Confidence' AS conceptType, scv.submission_level_label AS name) as confidence,
         scv.classification_comment as description,
         [
           STRUCT(

--- a/src/procedures/gks-vcv-statement-proc.sql
+++ b/src/procedures/gks-vcv-statement-proc.sql
@@ -67,7 +67,7 @@ BEGIN
           ) AS name
         ) AS strength,
 
-        sl.label AS confidence,
+        STRUCT('Confidence' AS conceptType, sl.label AS name) AS confidence,
 
         STRUCT(
           'Classification' AS conceptType,
@@ -137,7 +137,7 @@ BEGIN
           END AS name
         ) AS strength,
 
-        sl.label AS confidence,
+        STRUCT('Confidence' AS conceptType, sl.label AS name) AS confidence,
 
         STRUCT(
           'Classification' AS conceptType,
@@ -219,7 +219,7 @@ BEGIN
           END AS name
         ) AS strength,
 
-        agg.contributing_submission_level_label AS confidence,
+        STRUCT('Confidence' AS conceptType, agg.contributing_submission_level_label AS name) AS confidence,
 
         STRUCT(
           'Classification' AS conceptType,


### PR DESCRIPTION
## Summary
- Changes `confidence` from a plain string to `STRUCT('Confidence' AS conceptType, <label> AS name)` across all 3 statement procs
- Matches the `_CONCEPT_LABEL_TYPE` Parquet schema pattern used by classification, strength, and evidence_outcome
- All downstream layer assembly references (`l1.confidence`, `l2.confidence`, etc.) carry the struct through automatically

## Test plan
- [ ] Run all statement procs: `gks_scv_statement_proc`, `gks_vcv_statement_proc`, `gks_rcv_statement_proc`
- [ ] Verify SCV `confidence` is `{"conceptType": "Confidence", "name": "..."}` not a plain string
- [ ] Verify VCV/RCV classification and priority layer `confidence` has the struct form
- [ ] Verify VCV/RCV aggregate layer `confidence` has the struct form
- [ ] Verify nested evidenceItems carry `confidence` as struct through all layers