### PR TITLE
Task 0b-9: Use system URLs in coding.system output

### DIFF
--- a/src/procedures/gks-catvar-proc.sql
+++ b/src/procedures/gks-catvar-proc.sql
@@ -662,7 +662,7 @@ BEGIN
         SELECT
           vrs.in.variation_id,
           STRUCT(
-            'ClinVar' as system,
+            'https://www.ncbi.nlm.nih.gov/clinvar/' as system,
             vrs.in.variation_id as code,
             [FORMAT('https://identifiers.org/clinvar:%s',vrs.in.variation_id)] as iris
           ) as coding,
@@ -675,7 +675,7 @@ BEGIN
         SELECT
           x.variation_id,
           STRUCT(
-            x.db as system,
+            COALESCE(iri.system, x.db) as system,
             x.id as code,
             CASE LOWER(x.db)
             WHEN 'clinvar' THEN [FORMAT('https://identifiers.org/clinvar:%s',x.id)]
@@ -695,6 +695,12 @@ BEGIN
           ELSE 'relatedMatch'
           END as relation
         FROM `{S}.variation_xref` x
+        LEFT JOIN (
+          SELECT LOWER(db) as db_lower, ANY_VALUE(system) as system
+          FROM `clinvar_ingest.gks_xref_iri_templates`
+          WHERE category IN ('Variation', 'Tests')
+          GROUP BY LOWER(db)
+        ) iri ON iri.db_lower = LOWER(x.db)
       )
       SELECT
         m.variation_id,
@@ -747,7 +753,7 @@ BEGIN
             STRUCT(
               STRUCT(
                 'transcribed_to' as code,
-                'http://www.sequenceontology.org' as system,
+                'http://www.sequenceontology.org/' as system,
                 ['http://www.sequenceontology.org/browser/current_release/term/transcribed_to'] as iris
               ) as primaryCoding
             )

--- a/src/procedures/gks-scv-condition-proc.sql
+++ b/src/procedures/gks-scv-condition-proc.sql
@@ -93,7 +93,7 @@ BEGIN
         t.name,
         ARRAY_AGG(
           IF(
-            tx.mapping.system = 'medgen',
+            tx.mapping.system = 'https://www.ncbi.nlm.nih.gov/medgen/',
             tx.mapping,
             null
           )
@@ -101,7 +101,7 @@ BEGIN
         )[SAFE_OFFSET(0)] as primaryCoding,
         ARRAY_AGG(
           IF(
-            tx.mapping.system <> 'medgen',
+            tx.mapping.system <> 'https://www.ncbi.nlm.nih.gov/medgen/',
             STRUCT(tx.mapping as coding, 'relatedMatch' as relation),
             null
           )

--- a/src/procedures/setup-translation-tables.sql
+++ b/src/procedures/setup-translation-tables.sql
@@ -16,7 +16,7 @@
 --   type               - xref type qualifier (e.g. 'primary', 'MIM', 'Allelic variant').
 --                        Default is 'primary'. When a type-specific row exists for a
 --                        given db, only those rows are used for that (db, type) pair.
---   system             - optional system qualifier (e.g. 'NCBI', 'EBI'). Default is NULL.
+--   system             - code system URL (e.g. 'https://www.omim.org/'). Default is NULL.
 --   template           - URL template with a single %s placeholder for the id
 --   id_extract_pattern - optional regex applied to the raw id before substitution
 --                        (e.g. '\\d+' to strip a prefix like 'MONDO:0001234' → '0001234')
@@ -39,82 +39,82 @@ CREATE OR REPLACE TABLE `clinvar_ingest.gks_xref_iri_templates` (
 INSERT INTO `clinvar_ingest.gks_xref_iri_templates` (category, db, type, system, template, id_extract_pattern)
 VALUES
   -- Condition / Trait xrefs
-  ('Condition', 'MedGen',                   NULL,           'medgen', 'https://identifiers.org/medgen:%s',                                NULL),
-  ('Condition', 'MedGen',                   NULL,           'medgen', 'https://www.ncbi.nlm.nih.gov/medgen/%s',                          NULL),
+  ('Condition', 'MedGen',                   NULL,           'https://www.ncbi.nlm.nih.gov/medgen/', 'https://identifiers.org/medgen:%s',                                NULL),
+  ('Condition', 'MedGen',                   NULL,           'https://www.ncbi.nlm.nih.gov/medgen/', 'https://www.ncbi.nlm.nih.gov/medgen/%s',                          NULL),
 
-  ('Condition', 'OMIM',                     'MIM',               'omim', 'https://identifiers.org/mim:%s',                                   NULL),
-  ('Condition', 'OMIM',                     'MIM',               'omim', 'https://www.omim.org/entry/%s',                                    NULL),
-  ('Condition', 'OMIM',                     'Phenotypic series', 'omim.ps', 'https://www.omim.org/phenotypicSeries/%s',                       NULL),
+  ('Condition', 'OMIM',                     'MIM',               'https://www.omim.org/', 'https://identifiers.org/mim:%s',                                   NULL),
+  ('Condition', 'OMIM',                     'MIM',               'https://www.omim.org/', 'https://www.omim.org/entry/%s',                                    NULL),
+  ('Condition', 'OMIM',                     'Phenotypic series', 'https://www.omim.org/phenotypicSeries/', 'https://www.omim.org/phenotypicSeries/%s',                       NULL),
 
-  ('Condition', 'Human Phenotype Ontology', 'primary',           'HP', 'https://identifiers.org/HP:%s',                                       '\\d+'),
-  ('Condition', 'Human Phenotype Ontology', 'primary',           'HP', 'http://purl.obolibrary.org/obo/HP_%s',                               '\\d+'),
+  ('Condition', 'Human Phenotype Ontology', 'primary',           'https://hpo.jax.org/', 'https://identifiers.org/HP:%s',                                       '\\d+'),
+  ('Condition', 'Human Phenotype Ontology', 'primary',           'https://hpo.jax.org/', 'http://purl.obolibrary.org/obo/HP_%s',                               '\\d+'),
 
-  ('Condition', 'MONDO',                    NULL,           'mondo', 'https://identifiers.org/mondo:%s',                                 '\\d+'),
-  ('Condition', 'MONDO',                    NULL,           'mondo', 'http://purl.obolibrary.org/obo/MONDO_%s',                          '\\d+'),
+  ('Condition', 'MONDO',                    NULL,           'https://mondo.monarchinitiative.org/', 'https://identifiers.org/mondo:%s',                                 '\\d+'),
+  ('Condition', 'MONDO',                    NULL,           'https://mondo.monarchinitiative.org/', 'http://purl.obolibrary.org/obo/MONDO_%s',                          '\\d+'),
 
-  ('Condition', 'Orphanet',                 NULL,           'orpha', 'https://identifiers.org/orphanet:%s',                '\\d+'),
-  ('Condition', 'Orphanet',                 NULL,           'orpha', 'http://www.orpha.net/ORDO/Orphanet_%s',                            '\\d+'),
+  ('Condition', 'Orphanet',                 NULL,           'https://www.orpha.net/', 'https://identifiers.org/orphanet:%s',                '\\d+'),
+  ('Condition', 'Orphanet',                 NULL,           'https://www.orpha.net/', 'http://www.orpha.net/ORDO/Orphanet_%s',                            '\\d+'),
 
-  ('Condition', 'MeSH',                     NULL,           'mesh', 'https://identifiers.org/mesh:%s',                                  NULL),
-  ('Condition', 'MeSH',                     NULL,           'mesh', 'https://www.ncbi.nlm.nih.gov/mesh/?term=%s',                       NULL),
-  ('Condition', 'MSH',                      NULL,           'mesh', 'https://identifiers.org/mesh:%s',                                  NULL),
-  ('Condition', 'MSH',                      NULL,           'mesh', 'https://www.ncbi.nlm.nih.gov/mesh/?term=%s',                       NULL),
+  ('Condition', 'MeSH',                     NULL,           'https://id.nlm.nih.gov/mesh/', 'https://identifiers.org/mesh:%s',                                  NULL),
+  ('Condition', 'MeSH',                     NULL,           'https://id.nlm.nih.gov/mesh/', 'https://www.ncbi.nlm.nih.gov/mesh/?term=%s',                       NULL),
+  ('Condition', 'MSH',                      NULL,           'https://id.nlm.nih.gov/mesh/', 'https://identifiers.org/mesh:%s',                                  NULL),
+  ('Condition', 'MSH',                      NULL,           'https://id.nlm.nih.gov/mesh/', 'https://www.ncbi.nlm.nih.gov/mesh/?term=%s',                       NULL),
 
-  ('Condition', 'EFO',                      NULL,           'efo', 'https://identifiers.org/efo:%s',                                   '\\d+'),
-  ('Condition', 'EFO',                      NULL,           'efo', 'http://www.ebi.ac.uk/efo/EFO_%s',                                  '\\d+'),
-  ('Condition', 'EFO: The Experimental Factor Ontology', NULL, 'efo', 'https://identifiers.org/efo:%s',                                '\\d+'),
-  ('Condition', 'EFO: The Experimental Factor Ontology', NULL, 'efo', 'http://www.ebi.ac.uk/efo/EFO_%s',                               '\\d+'),
+  ('Condition', 'EFO',                      NULL,           'https://www.ebi.ac.uk/efo/', 'https://identifiers.org/efo:%s',                                   '\\d+'),
+  ('Condition', 'EFO',                      NULL,           'https://www.ebi.ac.uk/efo/', 'http://www.ebi.ac.uk/efo/EFO_%s',                                  '\\d+'),
+  ('Condition', 'EFO: The Experimental Factor Ontology', NULL, 'https://www.ebi.ac.uk/efo/', 'https://identifiers.org/efo:%s',                                '\\d+'),
+  ('Condition', 'EFO: The Experimental Factor Ontology', NULL, 'https://www.ebi.ac.uk/efo/', 'http://www.ebi.ac.uk/efo/EFO_%s',                               '\\d+'),
 
-  ('Condition', 'GeneReviews',              NULL,           'ncbibook',  'https://www.ncbi.nlm.nih.gov/books/%s',                            NULL),
+  ('Condition', 'GeneReviews',              NULL,           'https://www.ncbi.nlm.nih.gov/books/',  'https://www.ncbi.nlm.nih.gov/books/%s',                            NULL),
 
-  ('Condition', 'SNOMED CT',                NULL,           'snomedct',  'https://identifiers.org/snomedct:%s',                              NULL),
+  ('Condition', 'SNOMED CT',                NULL,           'https://www.snomed.org/',  'https://identifiers.org/snomedct:%s',                              NULL),
 
-  ('Condition', 'Genetic Testing Registry (GTR)', NULL,     'gtr.condition', 'https://www.ncbi.nlm.nih.gov/gtr/tests/%s',                       NULL),
+  ('Condition', 'Genetic Testing Registry (GTR)', NULL,     'https://www.ncbi.nlm.nih.gov/gtr/', 'https://www.ncbi.nlm.nih.gov/gtr/tests/%s',                       NULL),
 
-  ('Condition', 'NCI',                      NULL,           'ncit',      'http://purl.obolibrary.org/obo/NCIT_%s', NULL),
+  ('Condition', 'NCI',                      NULL,           'https://ncit.nci.nih.gov/',      'http://purl.obolibrary.org/obo/NCIT_%s', NULL),
 
-  ('Condition', 'Decipher',                 NULL,           'decipher',  'https://www.deciphergenomics.org/syndrome/%s',                     NULL),
+  ('Condition', 'Decipher',                 NULL,           'https://www.deciphergenomics.org/',  'https://www.deciphergenomics.org/syndrome/%s',                     NULL),
 
-  ('Condition', 'Medical Genetics Summaries', NULL,         'ncbibook',  'https://www.ncbi.nlm.nih.gov/books/%s',                            NULL),
+  ('Condition', 'Medical Genetics Summaries', NULL,         'https://www.ncbi.nlm.nih.gov/books/',  'https://www.ncbi.nlm.nih.gov/books/%s',                            NULL),
 
-  ('Condition', 'PharmGKB',                 NULL,           'pharmgkb',  'https://www.clinpgx.org/accession/%s',                              NULL),
-  ('Condition', 'PharmGKB',                 'drug',         'pharmgkb',  'https://www.clinpgx.org/accession/%s',                             NULL),
+  ('Condition', 'PharmGKB',                 NULL,           'https://www.pharmgkb.org/',  'https://www.clinpgx.org/accession/%s',                              NULL),
+  ('Condition', 'PharmGKB',                 'drug',         'https://www.pharmgkb.org/',  'https://www.clinpgx.org/accession/%s',                             NULL),
 
-  ('Condition', 'ClinPGx',                 NULL,           'pharmgkb',   'https://www.clinpgx.org/accession/%s',                              NULL),
-  ('Condition', 'ClinPGx',                 'drug',         'pharmgkb',   'https://www.clinpgx.org/accession/%s',                             NULL),
+  ('Condition', 'ClinPGx',                 NULL,           'https://www.pharmgkb.org/',   'https://www.clinpgx.org/accession/%s',                              NULL),
+  ('Condition', 'ClinPGx',                 'drug',         'https://www.pharmgkb.org/',   'https://www.clinpgx.org/accession/%s',                             NULL),
 
   -- Citation sources
-  ('Citation', 'PubMed',                   NULL,           'pubmed',   'https://pubmed.ncbi.nlm.nih.gov/%s',                              NULL),
-  ('Citation', 'pmc',                      NULL,           'pmc',      'https://europepmc.org/article/PMC/%s',                             NULL),
-  ('Citation', 'doi',                      NULL,           'doi',      'https://doi.org/%s',                                               NULL),
-  ('Citation', 'DOI',                      NULL,           'doi',      'https://doi.org/%s',                                               NULL),
-  ('Citation', 'Bookshelf',                NULL,           'ncbibook', 'https://www.ncbi.nlm.nih.gov/books/%s',                           NULL),
-  ('Citation', 'BookShelf',                NULL,           'ncbibook', 'https://www.ncbi.nlm.nih.gov/books/%s',                           NULL),
+  ('Citation', 'PubMed',                   NULL,           'https://pubmed.ncbi.nlm.nih.gov/',   'https://pubmed.ncbi.nlm.nih.gov/%s',                              NULL),
+  ('Citation', 'pmc',                      NULL,           'https://europepmc.org/',      'https://europepmc.org/article/PMC/%s',                             NULL),
+  ('Citation', 'doi',                      NULL,           'https://doi.org/',      'https://doi.org/%s',                                               NULL),
+  ('Citation', 'DOI',                      NULL,           'https://doi.org/',      'https://doi.org/%s',                                               NULL),
+  ('Citation', 'Bookshelf',                NULL,           'https://www.ncbi.nlm.nih.gov/books/', 'https://www.ncbi.nlm.nih.gov/books/%s',                           NULL),
+  ('Citation', 'BookShelf',                NULL,           'https://www.ncbi.nlm.nih.gov/books/', 'https://www.ncbi.nlm.nih.gov/books/%s',                           NULL),
 
   -- Gene namespaces
-  ('Gene', 'NCBIGene',                 NULL,           'ncbigene', 'https://identifiers.org/ncbigene:%s',                              NULL),
-  ('Gene', 'NCBIGene',                 NULL,           'ncbigene', 'https://www.ncbi.nlm.nih.gov/gene/%s',                             NULL),
-  ('Gene', 'HGNC',                     NULL,           'hgnc',     'https://identifiers.org/hgnc:%s',                                  '\\d+'),
-  ('Gene', 'HGNC',                     NULL,           'hgnc',     'https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/%s',  '\\d+'),
-  ('Gene', 'Gene',                     NULL,           'ncbigene', 'https://www.ncbi.nlm.nih.gov/gene/%s',                             NULL),
+  ('Gene', 'NCBIGene',                 NULL,           'https://www.ncbi.nlm.nih.gov/gene/', 'https://identifiers.org/ncbigene:%s',                              NULL),
+  ('Gene', 'NCBIGene',                 NULL,           'https://www.ncbi.nlm.nih.gov/gene/', 'https://www.ncbi.nlm.nih.gov/gene/%s',                             NULL),
+  ('Gene', 'HGNC',                     NULL,           'https://www.genenames.org/',     'https://identifiers.org/hgnc:%s',                                  '\\d+'),
+  ('Gene', 'HGNC',                     NULL,           'https://www.genenames.org/',     'https://www.genenames.org/data/gene-symbol-report/#!/hgnc_id/%s',  '\\d+'),
+  ('Gene', 'Gene',                     NULL,           'https://www.ncbi.nlm.nih.gov/gene/', 'https://www.ncbi.nlm.nih.gov/gene/%s',                             NULL),
 
   -- Variation xrefs (Cat-VRS)
-  ('Variation', 'ClinVar',           'Interpreted',        'clinvar.variation',  'https://www.ncbi.nlm.nih.gov/clinvar/variation/%s',                NULL),
-  ('Variation', 'ClinVar',           'Interpreted',        'clinvar.variation',  'https://identifiers.org/clinvar:%s',                               NULL),
-  ('Variation', 'ClinVar',           'Included',           'clinvar.variation',  'https://www.ncbi.nlm.nih.gov/clinvar/variation/%s',                NULL),
-  ('Variation', 'ClinVar',           'Included',           'clinvar.variation',  'https://identifiers.org/clinvar:%s',                               NULL),
+  ('Variation', 'ClinVar',           'Interpreted',        'https://www.ncbi.nlm.nih.gov/clinvar/',  'https://www.ncbi.nlm.nih.gov/clinvar/variation/%s',                NULL),
+  ('Variation', 'ClinVar',           'Interpreted',        'https://www.ncbi.nlm.nih.gov/clinvar/',  'https://identifiers.org/clinvar:%s',                               NULL),
+  ('Variation', 'ClinVar',           'Included',           'https://www.ncbi.nlm.nih.gov/clinvar/',  'https://www.ncbi.nlm.nih.gov/clinvar/variation/%s',                NULL),
+  ('Variation', 'ClinVar',           'Included',           'https://www.ncbi.nlm.nih.gov/clinvar/',  'https://identifiers.org/clinvar:%s',                               NULL),
   
-  ('Variation', 'ClinGen',                        NULL,    'clingen.allele',  'https://reg.clinicalgenome.org/redmine/projects/registry/genboree_registry/by_caid?caid=%s', NULL),
-  ('Variation', 'dbVar',                          NULL,    'dbvar.variant',   'https://www.ncbi.nlm.nih.gov/dbvar/variants/%s',                   NULL),
-  ('Variation', 'dbSNP',                          'rs',    'dbsnp',           'https://identifiers.org/dbsnp:rs%s',                               NULL),
-  ('Variation', 'PharmGKB Clinical Annotation',   NULL,    'pharmgkb',        'https://www.clinpgx.org/accession/%s',                             NULL),
-  ('Variation', 'UniProtKB',                      NULL,    'uniprot.var',     'http://purl.uniprot.org/annotation/VAR_%s',                        NULL),
-  ('Variation', 'UniProtKB/Swiss-Prot',           NULL,    'uniprot',         'http://purl.uniprot.org/annotation/VAR_%s',                        NULL),
-  ('Tests', 'Genetic Testing Registry (GTR)',     NULL,    'gtr.test',        'https://www.ncbi.nlm.nih.gov/gtr/tests/%s',                        NULL)
+  ('Variation', 'ClinGen',                        NULL,    'https://reg.clinicalgenome.org/',  'https://reg.clinicalgenome.org/redmine/projects/registry/genboree_registry/by_caid?caid=%s', NULL),
+  ('Variation', 'dbVar',                          NULL,    'https://www.ncbi.nlm.nih.gov/dbvar/',   'https://www.ncbi.nlm.nih.gov/dbvar/variants/%s',                   NULL),
+  ('Variation', 'dbSNP',                          'rs',    'https://www.ncbi.nlm.nih.gov/snp/',           'https://identifiers.org/dbsnp:rs%s',                               NULL),
+  ('Variation', 'PharmGKB Clinical Annotation',   NULL,    'https://www.pharmgkb.org/',        'https://www.clinpgx.org/accession/%s',                             NULL),
+  ('Variation', 'UniProtKB',                      NULL,    'https://www.uniprot.org/',     'http://purl.uniprot.org/annotation/VAR_%s',                        NULL),
+  ('Variation', 'UniProtKB/Swiss-Prot',           NULL,    'https://www.uniprot.org/',         'http://purl.uniprot.org/annotation/VAR_%s',                        NULL),
+  ('Tests', 'Genetic Testing Registry (GTR)',     NULL,    'https://www.ncbi.nlm.nih.gov/gtr/',        'https://www.ncbi.nlm.nih.gov/gtr/tests/%s',                        NULL)
 ;
 
 -- Rows requiring id_replace_pattern / id_replacement (all 6 columns)
 INSERT INTO `clinvar_ingest.gks_xref_iri_templates` (category, db, type, system, template, id_extract_pattern, id_replace_pattern, id_replacement)
 VALUES
-  ('Variation', 'OMIM',                     'Allelic variant',   'omim', 'https://www.omim.org/entry/%s',                                    NULL, '\\.', '#')
+  ('Variation', 'OMIM',                     'Allelic variant',   'https://www.omim.org/', 'https://www.omim.org/entry/%s',                                    NULL, '\\.', '#')
 ;


### PR DESCRIPTION
## Summary
- Update all `gks_xref_iri_templates` system column values from short names to proper URLs (e.g. `'medgen'` → `'https://www.ncbi.nlm.nih.gov/medgen/'`)
- Fix catvar proc to resolve variation xref system values via LEFT JOIN to the templates table instead of using raw `x.db` values
- Update condition proc medgen filter to match the new URL-based system value

## Test plan
- [ ] Re-run `setup-translation-tables.sql` to update the lookup table
- [ ] Re-run `gks_catvar_proc` and verify `gks_dict_variation.mappings[].coding[].system` values are URLs
- [ ] Re-run `gks_scv_condition_proc` and verify condition coding system values are URLs
- [ ] Verify no regressions in condition matching logic (internal `norm_codings` values unchanged)