### PR TITLE
Add Parquet output to release pipeline

### DIFF
--- a/src/scripts/assemble-gks-dicts.py
+++ b/src/scripts/assemble-gks-dicts.py
@@ -18,14 +18,19 @@ Usage:
   # Keep source files for debugging
   python3 assemble-gks-dicts.py gs://bucket/gks-dicts/ 2026-05-03 --keep-source
 
+  # Write Parquet files alongside the bundle
+  python3 assemble-gks-dicts.py gs://bucket/gks-dicts/ 2026-05-03 --parquet-dir=/tmp/parquet
+
   # From local files
   python3 assemble-gks-dicts.py ./gks-dicts/ 2026-05-03
 
 Dependencies:
   pip install orjson  # optional, 10-50x faster JSON; falls back to stdlib json
+  pip install pyarrow # optional, needed only when --parquet-dir is used
 """
 import argparse
 import gzip
+import json
 import re
 import shutil
 import subprocess
@@ -45,13 +50,21 @@ try:
         return orjson.dumps(key).decode()
 
 except ImportError:
-    import json
 
     def json_loads(s):
         return json.loads(s)
 
     def json_dumps_key(key):
         return json.dumps(key)
+
+
+# pyarrow is optional — only needed when --parquet-dir is used
+try:
+    import pyarrow as pa
+    import pyarrow.parquet as pq
+    _PYARROW_AVAILABLE = True
+except ImportError:
+    _PYARROW_AVAILABLE = False
 
 
 # Dictionary sections in output order.
@@ -77,6 +90,646 @@ SECTIONS = [
 WRITE_BUFFER_SIZE = 8 * 1024 * 1024  # 8MB write buffer
 GZIP_COMPRESS_LEVEL = 3  # faster than default 9, minimal size difference on JSON
 
+
+# ---------------------------------------------------------------------------
+# Parquet support (used only when --parquet-dir is passed)
+# ---------------------------------------------------------------------------
+
+PARQUET_BATCH_SIZE = 10_000
+
+SIMPLE_COLS = ["id", "data"]
+
+
+def _ref(value, prefix):
+    return (value or "").removeprefix(prefix) or None
+
+
+def _ref_if(value, prefix):
+    """Return the ID portion only if value starts with prefix; otherwise None."""
+    if value and value.startswith(prefix):
+        return value[len(prefix):]
+    return None
+
+
+def _name(concept):
+    return (concept or {}).get("name")
+
+
+def _exact_pos(p):
+    """Return int if p is an exact position; None if it's a range or absent."""
+    if p is None or isinstance(p, list):
+        return None
+    return int(p)
+
+
+def _range_pos(p):
+    """Return {"min": int, "max": int} if p is a [min, max] range; None if exact or absent."""
+    if isinstance(p, list):
+        return {"min": int(p[0]), "max": int(p[1])}
+    return None
+
+
+def _state_len_min(state):
+    """Lower bound of a state length (int or [min, max] range), as string or None."""
+    length = (state or {}).get("length")
+    if length is None:
+        return None
+    return str(length[0] if isinstance(length, list) else length)
+
+
+def _state_len_max(state):
+    """Upper bound of a state length (int or [min, max] range), as string or None."""
+    length = (state or {}).get("length")
+    if length is None:
+        return None
+    return str(length[1] if isinstance(length, list) else length)
+
+
+def _iris(v):
+    """Extract iris as a list of URI strings, or None."""
+    iris = v.get("iris")
+    if not iris:
+        return None
+    return [str(i) for i in iris]
+
+
+def _coding(c):
+    """Normalize a Coding object to match _CODING_TYPE, or return None."""
+    if c is None:
+        return None
+    return {
+        "id": c.get("id"),
+        "name": c.get("name"),
+        "code": c.get("code"),
+        "system": c.get("system"),
+        "system_version": c.get("systemVersion"),
+        "iris": [str(i) for i in c["iris"]] if c.get("iris") else None,
+        "extensions": _extensions(c),
+    }
+
+
+def _mappings(mappings):
+    """Normalize a mappings array to match _MAPPING_TYPE, or return None."""
+    if not mappings:
+        return None
+    return [
+        {
+            "coding": _coding(m.get("coding")),
+            "relation": m.get("relation"),
+            "extensions": _extensions(m),
+        }
+        for m in mappings
+    ]
+
+
+def _extensions(v):
+    """Extract extensions as [{name: str, value: str (JSON-encoded)}] or None."""
+    exts = v.get("extensions")
+    if not exts:
+        return None
+    return [
+        {
+            "name": e.get("name"),
+            "value": json.dumps(e["value"]) if e.get("value") is not None else None,
+        }
+        for e in exts
+    ]
+
+
+def _exprs(v):
+    """Extract expressions as [{syntax, value, syntax_version}] or None."""
+    exprs = v.get("expressions")
+    if not exprs:
+        return None
+    return [
+        {
+            "syntax": e.get("syntax"),
+            "value": e.get("value"),
+            "syntax_version": e.get("syntaxVersion"),
+        }
+        for e in exprs
+    ]
+
+
+def _concept_label(c):
+    """Extract classification/strength/evidenceOutcome as queryable struct, or None."""
+    if c is None:
+        return None
+    return {
+        "concept_type": c.get("conceptType") or c.get("type"),
+        "name": c.get("name"),
+        "primary_coding": _coding(c.get("primaryCoding")),
+        "extensions": _extensions(c),
+    }
+
+
+def _contributions(v):
+    """Extract contributions array to match _CONTRIBUTION_TYPE, or None."""
+    contribs = v.get("contributions")
+    if not contribs:
+        return None
+    return [
+        {
+            "type": c.get("type"),
+            "contributor": _ref(c.get("contributor"), "#/submitter/"),
+            "date": c.get("date"),
+            "activity_type": c.get("activityType"),
+        }
+        for c in contribs
+    ]
+
+
+def _reported_in(v):
+    """Extract reportedIn array to match _REPORTED_IN_TYPE, or None."""
+    docs = v.get("reportedIn")
+    if not docs:
+        return None
+    return [
+        {
+            "id": d.get("id"),
+            "name": d.get("name"),
+            "type": d.get("type"),
+            "document_type": d.get("documentType"),
+            "title": d.get("title"),
+            "doi": d.get("doi"),
+            "pmid": d.get("pmid"),
+            "urls": d.get("urls") or None,
+        }
+        for d in docs
+    ]
+
+
+def _specified_by(v):
+    """Extract specifiedBy struct to match _SPECIFIED_BY_TYPE, or None."""
+    sb = v.get("specifiedBy")
+    if sb is None:
+        return None
+    reported_in = sb.get("reportedIn")
+    return {
+        "name": sb.get("name"),
+        "method_type": sb.get("methodType"),
+        "type": sb.get("type"),
+        "reported_in": json.dumps(reported_in) if reported_in else None,
+    }
+
+
+def _mappable_concept(mc):
+    """Normalize a MappableConcept dict to match _MAPPABLE_CONCEPT_TYPE, or return None."""
+    if mc is None:
+        return None
+    return {
+        "id": mc.get("id"),
+        "name": mc.get("name"),
+        "aliases": mc.get("aliases") or None,
+        "primary_coding": _coding(mc.get("primaryCoding")),
+        "iris": [str(i) for i in mc["iris"]] if mc.get("iris") else None,
+        "extensions": _extensions(mc),
+    }
+
+
+def _constraints(v):
+    """Extract variation constraints array to match _CONSTRAINT_TYPE, or return None."""
+    constraints = v.get("constraints")
+    if not constraints:
+        return None
+    result = []
+    for c in constraints:
+        copies_val = c.get("copies")
+        result.append({
+            "type": c.get("type"),
+            "allele": c.get("allele"),
+            "location": c.get("location"),
+            "relations": [_mappable_concept(r) for r in c.get("relations") or []] or None,
+            "match_characteristic": _mappable_concept(c.get("matchCharacteristic")),
+            "copies": _exact_pos(copies_val),
+            "copies_range": _range_pos(copies_val),
+            "copy_change": c.get("copyChange"),
+        })
+    return result
+
+
+# pyarrow types for columns that are not plain strings.
+_RANGE_TYPE = pa.struct([pa.field("min", pa.int64()), pa.field("max", pa.int64())]) if _PYARROW_AVAILABLE else None
+_EXTENSION_TYPE = pa.list_(
+    pa.struct([pa.field("name", pa.string()), pa.field("value", pa.string())])
+) if _PYARROW_AVAILABLE else None
+_IRIS_TYPE = pa.list_(pa.string()) if _PYARROW_AVAILABLE else None
+_EXPRESSION_TYPE = pa.list_(pa.struct([
+    pa.field("syntax", pa.string()),
+    pa.field("value", pa.string()),
+    pa.field("syntax_version", pa.string()),
+])) if _PYARROW_AVAILABLE else None
+
+_CODING_TYPE = pa.struct([
+    pa.field("id", pa.string()),
+    pa.field("name", pa.string()),
+    pa.field("code", pa.string()),
+    pa.field("system", pa.string()),
+    pa.field("system_version", pa.string()),
+    pa.field("iris", _IRIS_TYPE),
+    pa.field("extensions", _EXTENSION_TYPE),
+]) if _PYARROW_AVAILABLE else None
+
+_MAPPING_TYPE = pa.list_(pa.struct([
+    pa.field("coding", _CODING_TYPE),
+    pa.field("relation", pa.string()),
+    pa.field("extensions", _EXTENSION_TYPE),
+])) if _PYARROW_AVAILABLE else None
+
+_MAPPABLE_CONCEPT_TYPE = pa.struct([
+    pa.field("id", pa.string()),
+    pa.field("name", pa.string()),
+    pa.field("aliases", _IRIS_TYPE),
+    pa.field("primary_coding", _CODING_TYPE),
+    pa.field("iris", _IRIS_TYPE),
+    pa.field("extensions", _EXTENSION_TYPE),
+]) if _PYARROW_AVAILABLE else None
+
+_CONCEPT_LABEL_TYPE = pa.struct([
+    pa.field("concept_type", pa.string()),
+    pa.field("name", pa.string()),
+    pa.field("primary_coding", _CODING_TYPE),
+    pa.field("extensions", _EXTENSION_TYPE),
+]) if _PYARROW_AVAILABLE else None
+
+_CONTRIBUTION_TYPE = pa.list_(pa.struct([
+    pa.field("type", pa.string()),
+    pa.field("contributor", pa.string()),
+    pa.field("date", pa.string()),
+    pa.field("activity_type", pa.string()),
+])) if _PYARROW_AVAILABLE else None
+
+_REPORTED_IN_TYPE = pa.list_(pa.struct([
+    pa.field("id", pa.string()),
+    pa.field("name", pa.string()),
+    pa.field("type", pa.string()),
+    pa.field("document_type", pa.string()),
+    pa.field("title", pa.string()),
+    pa.field("doi", pa.string()),
+    pa.field("pmid", pa.string()),
+    pa.field("urls", pa.list_(pa.string())),
+])) if _PYARROW_AVAILABLE else None
+
+_SPECIFIED_BY_TYPE = pa.struct([
+    pa.field("name", pa.string()),
+    pa.field("method_type", pa.string()),
+    pa.field("type", pa.string()),
+    pa.field("reported_in", pa.string()),
+]) if _PYARROW_AVAILABLE else None
+
+_CONSTRAINT_TYPE = pa.list_(pa.struct([
+    pa.field("type", pa.string()),
+    pa.field("allele", pa.string()),
+    pa.field("location", pa.string()),
+    pa.field("relations", pa.list_(_MAPPABLE_CONCEPT_TYPE)),
+    pa.field("match_characteristic", _MAPPABLE_CONCEPT_TYPE),
+    pa.field("copies", pa.int64()),
+    pa.field("copies_range", _RANGE_TYPE),
+    pa.field("copy_change", pa.string()),
+])) if _PYARROW_AVAILABLE else None
+
+_COLUMN_TYPES = {
+    "start":               _RANGE_TYPE and pa.int64(),
+    "end":                 _RANGE_TYPE and pa.int64(),
+    "start_range":         _RANGE_TYPE,
+    "end_range":           _RANGE_TYPE,
+    "copies":              _RANGE_TYPE and pa.int64(),
+    "expressions":         _EXPRESSION_TYPE,
+    "extensions":          _EXTENSION_TYPE,
+    "iris":                _IRIS_TYPE,
+    "aliases":             pa.list_(pa.string()) if _PYARROW_AVAILABLE else None,
+    "concepts":            pa.list_(pa.string()) if _PYARROW_AVAILABLE else None,
+    "primary_coding":      _CODING_TYPE,
+    "mappings":            _MAPPING_TYPE,
+    "classification":               _CONCEPT_LABEL_TYPE,
+    "strength":                     _CONCEPT_LABEL_TYPE,
+    "confidence":                   _CONCEPT_LABEL_TYPE,
+    "contributions":                _CONTRIBUTION_TYPE,
+    "reported_in":                  _REPORTED_IN_TYPE,
+    "specified_by":                 _SPECIFIED_BY_TYPE,
+    "evidence_outcome":            _CONCEPT_LABEL_TYPE,
+    "strength_of_evidence_provided": _CONCEPT_LABEL_TYPE,
+    "has_evidence_lines":          pa.list_(pa.string()) if _PYARROW_AVAILABLE else None,
+    "has_evidence_items":          pa.list_(pa.string()) if _PYARROW_AVAILABLE else None,
+    "constraints":                  _CONSTRAINT_TYPE,
+    "match_characteristic":         _MAPPABLE_CONCEPT_TYPE,
+    "gene_context_qualifier":       _MAPPABLE_CONCEPT_TYPE,
+    "mode_of_inheritance_qualifier": _MAPPABLE_CONCEPT_TYPE,
+    "penetrance_qualifier":         _MAPPABLE_CONCEPT_TYPE,
+} if _PYARROW_AVAILABLE else {}
+
+
+def _make_schema(col_names):
+    """Build a pyarrow schema; special column names get typed, everything else is string."""
+    return pa.schema([
+        pa.field(c, _COLUMN_TYPES.get(c, pa.string()))
+        for c in col_names
+    ])
+
+
+SIMPLE_SCHEMA = _make_schema(SIMPLE_COLS) if _PYARROW_AVAILABLE else None
+
+
+PARQUET_SECTION_CONFIGS = {
+    "sequenceReference": (
+        ["id", "refget_accession", "name", "aliases",
+         "molecule_type", "residue_alphabet", "extensions", "data"],
+        lambda k, v: (
+            k,
+            v.get("refgetAccession"),
+            v.get("name"),
+            v.get("aliases") or None,
+            v.get("moleculeType"),
+            v.get("residueAlphabet"),
+            _extensions(v),
+            json.dumps(v),
+        ),
+    ),
+    "location": (
+        ["id", "digest", "sequence_reference_id", "name", "aliases",
+         "start", "end", "start_range", "end_range",
+         "extensions", "data"],
+        lambda k, v: (
+            k,
+            v.get("digest"),
+            _ref(v.get("sequenceReference"), "#/sequenceReference/"),
+            v.get("name"),
+            v.get("aliases") or None,
+            _exact_pos(v.get("start")),
+            _exact_pos(v.get("end")),
+            _range_pos(v.get("start")),
+            _range_pos(v.get("end")),
+            _extensions(v),
+            json.dumps(v),
+        ),
+    ),
+    "allele": (
+        ["id", "digest", "location_id", "name", "aliases",
+         "state_type", "state_sequence",
+         "state_length_min", "state_length_max",
+         "expressions", "extensions", "state"],
+        lambda k, v: (
+            k,
+            v.get("digest"),
+            _ref(v.get("location"), "#/location/"),
+            v.get("name"),
+            v.get("aliases") or None,
+            (v.get("state") or {}).get("type"),
+            (v.get("state") or {}).get("sequence"),
+            _state_len_min(v.get("state")),
+            _state_len_max(v.get("state")),
+            _exprs(v),
+            _extensions(v),
+            json.dumps(v.get("state")),
+        ),
+    ),
+    "copyNumberCount": (
+        ["id", "digest", "location_id", "name", "aliases",
+         "copies", "extensions", "data"],
+        lambda k, v: (
+            k,
+            v.get("digest"),
+            _ref(v.get("location"), "#/location/"),
+            v.get("name"),
+            v.get("aliases") or None,
+            v.get("copies"),
+            _extensions(v),
+            json.dumps(v),
+        ),
+    ),
+    "copyNumberChange": (
+        ["id", "digest", "location_id", "name", "aliases",
+         "copy_change", "extensions", "data"],
+        lambda k, v: (
+            k,
+            v.get("digest"),
+            _ref(v.get("location"), "#/location/"),
+            v.get("name"),
+            v.get("aliases") or None,
+            v.get("copyChange"),
+            _extensions(v),
+            json.dumps(v),
+        ),
+    ),
+    "gene": (
+        ["id", "name", "aliases",
+         "primary_coding", "mappings", "iris", "extensions", "data"],
+        lambda k, v: (
+            k,
+            v.get("name"),
+            v.get("aliases") or None,
+            _coding(v.get("primaryCoding")),
+            _mappings(v.get("mappings")),
+            _iris(v),
+            _extensions(v),
+            json.dumps(v),
+        ),
+    ),
+    "variation": (
+        ["id", "name", "aliases", "mappings", "extensions", "constraints", "data"],
+        lambda k, v: (
+            k,
+            v.get("name"),
+            v.get("aliases") or None,
+            _mappings(v.get("mappings")),
+            _extensions(v),
+            _constraints(v),
+            json.dumps(v),
+        ),
+    ),
+    "condition": (
+        ["id", "concept_type", "name", "aliases",
+         "primary_coding", "mappings", "iris", "extensions", "data"],
+        lambda k, v: (
+            k,
+            v.get("conceptType"),
+            v.get("name"),
+            v.get("aliases") or None,
+            _coding(v.get("primaryCoding")),
+            _mappings(v.get("mappings")),
+            _iris(v),
+            _extensions(v),
+            json.dumps(v),
+        ),
+    ),
+    "conditionSet": (
+        ["id", "concept_set_type", "membership_operator", "concepts", "extensions", "data"],
+        lambda k, v: (
+            k,
+            v.get("conceptSetType"),
+            v.get("membershipOperator"),
+            v.get("concepts") or None,
+            _extensions(v),
+            json.dumps(v),
+        ),
+    ),
+    "submitter": (
+        ["id", "name", "type", "agent_type", "data"],
+        lambda k, v: (
+            k,
+            v.get("name"),
+            v.get("type", "Agent"),
+            v.get("agentType", "organization"),
+            json.dumps(v),
+        ),
+    ),
+    "proposition": (
+        ["id", "name", "subject_variant",
+         "predicate",
+         "object_condition", "object_condition_set",
+         "type",
+         "gene_context_qualifier",
+         "mode_of_inheritance_qualifier",
+         "penetrance_qualifier",
+         "extensions", "data"],
+        lambda k, v: (
+            k,
+            v.get("name"),
+            _ref(v.get("subject"), "#/variation/"),
+            v.get("predicate"),
+            _ref_if(v.get("object"), "#/condition/"),
+            _ref_if(v.get("object"), "#/conditionSet/"),
+            v.get("type"),
+            _mappable_concept(v.get("geneContextQualifier")),
+            _mappable_concept(v.get("modeOfInheritanceQualifier")),
+            _mappable_concept(v.get("penetranceQualifier")),
+            _extensions(v),
+            json.dumps(v),
+        ),
+    ),
+    "scv": (
+        ["id", "type", "proposition_id",
+         "classification", "strength",
+         "direction", "confidence", "description",
+         "contributions", "reported_in", "specified_by", "has_evidence_lines",
+         "extensions", "data"],
+        lambda k, v: (
+            k,
+            v.get("type"),
+            _ref(v.get("proposition"), "#/proposition/"),
+            _concept_label(v.get("classification")),
+            _concept_label(v.get("strength")),
+            v.get("direction"),
+            _concept_label(v.get("confidence")),
+            v.get("description"),
+            _contributions(v),
+            _reported_in(v),
+            _specified_by(v),
+            v.get("hasEvidenceLines") or None,
+            _extensions(v),
+            json.dumps(v),
+        ),
+    ),
+    "evidenceLine": (
+        ["id", "type", "proposition_id",
+         "direction_of_evidence_provided",
+         "evidence_outcome", "strength_of_evidence_provided",
+         "has_evidence_lines", "has_evidence_items",
+         "extensions", "data"],
+        lambda k, v: (
+            k,
+            v.get("type"),
+            _ref(v.get("proposition"), "#/proposition/"),
+            v.get("directionOfEvidenceProvided"),
+            _concept_label(v.get("evidenceOutcome")),
+            _concept_label(v.get("strengthOfEvidenceProvided")),
+            v.get("hasEvidenceLines") or None,
+            v.get("hasEvidenceItems") or None,
+            _extensions(v),
+            json.dumps(v),
+        ),
+    ),
+    "vcv": (
+        ["id", "type", "proposition_id",
+         "classification", "strength",
+         "direction", "confidence",
+         "has_evidence_lines",
+         "extensions", "data"],
+        lambda k, v: (
+            k,
+            v.get("type"),
+            _ref(v.get("proposition"), "#/proposition/"),
+            _concept_label(v.get("classification")),
+            _concept_label(v.get("strength")),
+            v.get("direction"),
+            _concept_label(v.get("confidence")),
+            v.get("hasEvidenceLines") or None,
+            _extensions(v),
+            json.dumps(v),
+        ),
+    ),
+    "rcv": (
+        ["id", "type", "proposition_id",
+         "classification", "strength",
+         "direction", "confidence",
+         "has_evidence_lines",
+         "extensions", "data"],
+        lambda k, v: (
+            k,
+            v.get("type"),
+            _ref(v.get("proposition"), "#/proposition/"),
+            _concept_label(v.get("classification")),
+            _concept_label(v.get("strength")),
+            v.get("direction"),
+            _concept_label(v.get("confidence")),
+            v.get("hasEvidenceLines") or None,
+            _extensions(v),
+            json.dumps(v),
+        ),
+    ),
+}
+
+
+def open_parquet_writers(parquet_dir):
+    """Open one ParquetWriter per section. Returns {section: (writer, batch, col_names, schema)}."""
+    import os
+    os.makedirs(parquet_dir, exist_ok=True)
+    writers = {}
+    for section_name, _, _, _ in SECTIONS:
+        col_names = (
+            PARQUET_SECTION_CONFIGS[section_name][0]
+            if section_name in PARQUET_SECTION_CONFIGS
+            else SIMPLE_COLS
+        )
+        schema = _make_schema(col_names)
+        path = os.path.join(parquet_dir, f"{section_name}.parquet")
+        writer = pq.ParquetWriter(path, schema, compression="zstd")
+        batch = {col: [] for col in col_names}
+        writers[section_name] = (writer, batch, col_names, schema)
+    return writers
+
+
+def _flush_parquet(writer, batch, col_names, schema):
+    if batch[col_names[0]]:
+        writer.write_table(pa.table(batch, schema=schema))
+        for col in col_names:
+            batch[col].clear()
+
+
+def _add_parquet_record(writer_state, pq_id, pq_data_str, section_name, entry_count):
+    """Append one record to the Parquet batch; flush every PARQUET_BATCH_SIZE records."""
+    writer, batch, col_names, schema = writer_state
+    if section_name in PARQUET_SECTION_CONFIGS:
+        _, extractor = PARQUET_SECTION_CONFIGS[section_name]
+        row = extractor(pq_id, json_loads(pq_data_str))
+    else:
+        row = (pq_id, pq_data_str)
+    for col, val in zip(col_names, row):
+        batch[col].append(val)
+    if entry_count % PARQUET_BATCH_SIZE == 0:
+        _flush_parquet(writer, batch, col_names, schema)
+
+
+def close_parquet_writers(writers):
+    """Flush remaining batches and close all writers."""
+    for writer, batch, col_names, schema in writers.values():
+        _flush_parquet(writer, batch, col_names, schema)
+        writer.close()
+
+
+# ---------------------------------------------------------------------------
+# Bundle assembly
+# ---------------------------------------------------------------------------
 
 def list_gcs_files(gcs_prefix):
     """List all files under a GCS prefix."""
@@ -163,14 +816,17 @@ def open_output(output_path):
     return open(output_path, "wb")
 
 
-def assemble(source, output_path, is_gcs):
+def assemble(source, output_path, is_gcs, parquet_dir=None):
     """
     Assemble all dictionary NDJSON sections into a single keyed JSON file.
     For GCS sources, downloads one section at a time to minimise disk usage.
+    Optionally writes typed Parquet files when parquet_dir is set.
     """
     section_count = 0
     total_entries = 0
     start_time = time.time()
+
+    parquet_writers = open_parquet_writers(parquet_dir) if parquet_dir else {}
 
     # List GCS files once upfront
     all_gcs_files = list_gcs_files(source) if is_gcs else []
@@ -219,6 +875,14 @@ def assemble(source, output_path, is_gcs):
                                 buf.extend(b",\n")
                             first_entry = False
                             buf.extend(f"    {key_json}: {raw_json}".encode())
+                            if parquet_writers:
+                                _add_parquet_record(
+                                    parquet_writers[section_name],
+                                    json_loads(key_json),
+                                    raw_json,
+                                    section_name,
+                                    entry_count,
+                                )
                             entry_count += 1
                             if len(buf) >= WRITE_BUFFER_SIZE:
                                 out.write(bytes(buf))
@@ -230,6 +894,14 @@ def assemble(source, output_path, is_gcs):
                                 buf.extend(b",\n")
                             first_entry = False
                             buf.extend(f"    {key_json}: {value_json}".encode())
+                            if parquet_writers:
+                                _add_parquet_record(
+                                    parquet_writers[section_name],
+                                    json_loads(key_json),
+                                    value_json,
+                                    section_name,
+                                    entry_count,
+                                )
                             entry_count += 1
                             if len(buf) >= WRITE_BUFFER_SIZE:
                                 out.write(bytes(buf))
@@ -251,11 +923,15 @@ def assemble(source, output_path, is_gcs):
 
     finally:
         out.close()
+        if parquet_writers:
+            close_parquet_writers(parquet_writers)
 
     elapsed = time.time() - start_time
+    pq_msg = f", {len(parquet_writers)} Parquet files" if parquet_writers else ""
     print(
         f"\nDone: {section_count} sections, "
         f"{total_entries:,} total entries in {elapsed:.1f}s"
+        f"{pq_msg}"
         f" -> {output_path}"
     )
 
@@ -295,6 +971,11 @@ def main():
         "--copy-to-gcs", action="store_true",
         help="Copy the assembled bundle to GCS after local assembly",
     )
+    parser.add_argument(
+        "--parquet-dir",
+        metavar="DIR",
+        help="Write per-section typed Parquet files to DIR alongside the bundle",
+    )
     args = parser.parse_args()
 
     if not re.match(r"^\d{4}-\d{2}-\d{2}$", args.date):
@@ -306,13 +987,18 @@ def main():
     if not is_gcs and not Path(source).is_dir():
         parser.error(f"{source} is not a directory or GCS path")
 
+    if args.parquet_dir and not _PYARROW_AVAILABLE:
+        parser.error("--parquet-dir requires pyarrow: pip install pyarrow")
+
     output_path = derive_output_path(args.date)
 
     print(f"Assembling GKS dictionaries from {source}")
     print(f"  Output: {output_path}")
+    if args.parquet_dir:
+        print(f"  Parquet: {args.parquet_dir}")
     print(f"  Using {'orjson' if 'orjson' in sys.modules else 'stdlib json (pip install orjson for 10-50x speedup)'}")
 
-    assemble(source, output_path, is_gcs)
+    assemble(source, output_path, is_gcs, parquet_dir=args.parquet_dir)
 
     if args.copy_to_gcs and is_gcs:
         gcs_path = derive_gcs_path(source, args.date)

--- a/src/scripts/release-gks.sh
+++ b/src/scripts/release-gks.sh
@@ -75,6 +75,7 @@ else
 fi
 
 BUNDLE_FILE="/tmp/clinvar-gks-${EXPORT_DATE}.json.gz"
+PARQUET_DIR="/tmp/clinvar-gks-${EXPORT_DATE}-parquet"
 
 echo "=== ClinVar-GKS Release Pipeline ==="
 echo "  Release date:  ${EXPORT_DATE}"
@@ -82,6 +83,7 @@ echo "  Version:       ${DATASET_VERSION}"
 echo "  BQ dataset:    ${BQ_DATASET}"
 echo "  GCS dicts:     ${GCS_DICTS_PATH}/"
 echo "  Bundle:        ${BUNDLE_FILE}"
+echo "  Parquet dir:   ${PARQUET_DIR}"
 $DRY_RUN && echo "  Mode:          DRY RUN"
 $KEEP_SOURCE && echo "  Keep source:   YES"
 [[ "$START_STEP" -gt 1 ]] && echo "  Start step:    ${START_STEP}"
@@ -113,7 +115,7 @@ fi
 
 if [[ "$START_STEP" -le 2 ]]; then
   echo "=== Step 2/3: Assembling bundle ==="
-  ASSEMBLE_ARGS=("${GCS_DICTS_PATH}/" "${EXPORT_DATE}")
+  ASSEMBLE_ARGS=("${GCS_DICTS_PATH}/" "${EXPORT_DATE}" "--parquet-dir=${PARQUET_DIR}")
   if $KEEP_SOURCE; then
     ASSEMBLE_ARGS+=("--keep-source")
   fi
@@ -134,7 +136,7 @@ fi
 # =====================================================================
 
 echo "=== Step 3/3: Uploading to R2 ==="
-UPLOAD_ARGS=("${EXPORT_DATE}" "${DATASET_VERSION}" "${BUNDLE_FILE}")
+UPLOAD_ARGS=("${EXPORT_DATE}" "${DATASET_VERSION}" "${BUNDLE_FILE}" "--parquet-dir=${PARQUET_DIR}")
 if $DRY_RUN; then
   UPLOAD_ARGS+=("--dry-run")
 fi
@@ -144,4 +146,5 @@ fi
 # --- Cleanup local bundle ---
 if ! $DRY_RUN; then
   rm -f "${BUNDLE_FILE}"
+  rm -rf "${PARQUET_DIR}"
 fi

--- a/src/scripts/upload-gks-to-r2.sh
+++ b/src/scripts/upload-gks-to-r2.sh
@@ -47,12 +47,14 @@ fi
 
 # --- Parse flags ---
 DRY_RUN=false
+PARQUET_DIR=""
 for arg in "$@"; do
   case "$arg" in
     --dry-run) DRY_RUN=true ;;
+    --parquet-dir=*) PARQUET_DIR="${arg#--parquet-dir=}" ;;
     *)
       echo "ERROR: Unknown argument '${arg}'"
-      echo "Usage: $0 <export_date> <dataset_version> [--dry-run]"
+      echo "Usage: $0 <export_date> <dataset_version> <bundle_file> [--dry-run] [--parquet-dir=DIR]"
       exit 1
       ;;
   esac
@@ -210,6 +212,29 @@ cleanup_prior_weeklies() {
   done
 }
 
+upload_parquet() {
+  local parquet_dir="$1"
+  if [[ -z "$parquet_dir" || ! -d "$parquet_dir" ]]; then
+    echo "  (no Parquet dir found, skipping)"
+    return
+  fi
+
+  echo "--- Uploading Parquet section files ---"
+  local uploaded=0
+  for parquet_file in "${parquet_dir}"/*.parquet; do
+    [[ -f "$parquet_file" ]] || continue
+    local section
+    section="$(basename "${parquet_file}" .parquet)"
+    echo "  datasets/parquet/${section}.parquet"
+    r2_upload \
+      "${parquet_file}" \
+      "datasets/parquet/${section}.parquet" \
+      "application/vnd.apache.parquet"
+    (( uploaded++ )) || true
+  done
+  echo "  ${uploaded} Parquet files uploaded."
+}
+
 promote_monthly() {
   # Promote the last weekly from the prior month as that month's monthly release.
   # Must run before archive_yearly (so promoted monthly gets swept to archives on year rollover).
@@ -218,7 +243,7 @@ promote_monthly() {
     return
   fi
 
-  local last="${EXISTING_WEEKLY_FILES[-1]}"
+  local last="${EXISTING_WEEKLY_FILES[${#EXISTING_WEEKLY_FILES[@]}-1]}"
   PREV_MONTHLY_FILE="clinvar-gks_${YEAR}-${MM}.json.gz"
 
   echo "--- Month rollover: promoting last prior weekly to monthly ---"
@@ -282,6 +307,12 @@ r2_upload "${LOCAL_TMP}" "datasets/weekly/${WEEKLY_FILE}"
 
 echo "  Updating datasets/weekly/${LATEST_WEEKLY}"
 r2_upload "${LOCAL_TMP}" "datasets/weekly/${LATEST_WEEKLY}"
+
+# --- Upload Parquet files (if generated) ---
+if [[ -n "${PARQUET_DIR}" ]]; then
+  echo ""
+  upload_parquet "${PARQUET_DIR}"
+fi
 
 # --- Upload README.txt ---
 README_SRC="${SCRIPT_DIR}/r2-readme.txt"
@@ -376,5 +407,8 @@ echo "  Latest:  ${R2_PUBLIC_URL}/datasets/weekly/${LATEST_WEEKLY}"
 if $IS_NEW_MONTH && [[ -n "${PREV_MONTHLY_FILE:-}" ]]; then
   echo "  Monthly: ${R2_PUBLIC_URL}/datasets/${PREV_MONTHLY_FILE}"
   echo "  Latest:  ${R2_PUBLIC_URL}/datasets/${LATEST_MONTHLY}"
+fi
+if [[ -n "${PARQUET_DIR}" && -d "${PARQUET_DIR}" ]]; then
+  echo "  Parquet: ${R2_PUBLIC_URL}/datasets/parquet/"
 fi
 echo "  Index:   ${R2_PUBLIC_URL}/index.json"


### PR DESCRIPTION
## Summary
- Add `--parquet-dir` to `assemble-gks-dicts.py`: emits 15 typed Parquet files (ZSTD compressed) during the same streaming pass used for bundle assembly
- Wire `PARQUET_DIR` through `release-gks.sh` (assembler + uploader + cleanup)
- Add `--parquet-dir` to `upload-gks-to-r2.sh`: uploads `.parquet` files to `datasets/parquet/` on R2
- Fix Bash 3.2 compatibility issue (negative array index) in upload script

Each Parquet section has a custom typed schema:
- `int64` for genomic positions and copy counts
- Structs for concepts, codings, mappings, contributions
- Lists for arrays (aliases, iris, evidence lines)
- Raw JSON `data` column for full record access

## Validation
Tested against full `clinvar_2026_04_26_v2_4_4` dataset:
- 15 sections, 86.4M total records assembled in ~36 minutes
- All 15 Parquet files valid with correct schemas and row counts
- Dry-run of release pipeline shows correct arg passing

## Test plan
- [x] `python3 -m py_compile` passes
- [x] `bash -n` passes on both shell scripts
- [x] Dry-run `release-gks.sh` shows `--parquet-dir` in assembler and uploader args
- [x] Full assembly run produces valid Parquet files with correct typed schemas
- [x] Row counts match bundle section entry counts
- [ ] Dry-run upload shows `[dry-run] upload: datasets/parquet/*.parquet` lines